### PR TITLE
feat: add retention policy for cloudwatch log groups to expire 3 days…

### DIFF
--- a/src/terraform/cloudwatch.tf
+++ b/src/terraform/cloudwatch.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "retention_policy" {
+  for_each          = merge(var.websocket_lambdas, var.rest_lambdas)
+  name              = "/aws/lambda/${each.key}"
+  retention_in_days = 3
+}
+
+
+

--- a/src/terraform/terraform.tfstate
+++ b/src/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.7.5",
-  "serial": 2408,
+  "serial": 2465,
   "lineage": "2358f90d-604f-5fa9-5f28-fc15441c7608",
   "outputs": {},
   "resources": [
@@ -205,9 +205,9 @@
             "api_id": "b1bgyojlzj",
             "auto_deployed": false,
             "description": "",
-            "id": "cr5ylh",
+            "id": "ivohvu",
             "triggers": {
-              "redeployment": "892b664cc94036922a0def415644feb82d7907e7"
+              "redeployment": "43dfb235846b8f933909e82241fbd3f0607de06d"
             }
           },
           "sensitive_attributes": [],
@@ -408,8 +408,8 @@
             "integration_uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:makeMove/invocations",
             "passthrough_behavior": "WHEN_NO_MATCH",
             "payload_format_version": "1.0",
-            "request_parameters": null,
-            "request_templates": null,
+            "request_parameters": {},
+            "request_templates": {},
             "response_parameters": [],
             "template_selection_expression": "",
             "timeout_milliseconds": 29000,
@@ -614,13 +614,13 @@
           "attributes": {
             "api_id": "b1bgyojlzj",
             "api_key_required": false,
-            "authorization_scopes": null,
+            "authorization_scopes": [],
             "authorization_type": "NONE",
             "authorizer_id": "",
             "id": "viwhs4a",
             "model_selection_expression": "",
             "operation_name": "",
-            "request_models": null,
+            "request_models": {},
             "request_parameter": [],
             "route_key": "makeMove",
             "route_response_selection_expression": "",
@@ -726,7 +726,7 @@
                 "throttling_rate_limit": 2
               }
             ],
-            "deployment_id": "cr5ylh",
+            "deployment_id": "ivohvu",
             "description": "",
             "execution_arn": "arn:aws:execute-api:us-east-1:891377152062:b1bgyojlzj/dev",
             "id": "dev",
@@ -753,6 +753,194 @@
             "aws_s3_object.project_jar",
             "random_pet.lambda_bucket_name"
           ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_cloudwatch_log_group",
+      "name": "retention_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": "auth",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/auth",
+            "id": "/aws/lambda/auth",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/auth",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/default",
+            "id": "/aws/lambda/default",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/default",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "disconnect",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/disconnect",
+            "id": "/aws/lambda/disconnect",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/disconnect",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "joinGame",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/joinGame",
+            "id": "/aws/lambda/joinGame",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/joinGame",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "login",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/login",
+            "id": "/aws/lambda/login",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/login",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "logout",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/logout",
+            "id": "/aws/lambda/logout",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/logout",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "makeMove",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/makeMove",
+            "id": "/aws/lambda/makeMove",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/makeMove",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "message",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/message",
+            "id": "/aws/lambda/message",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/message",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "register",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/register",
+            "id": "/aws/lambda/register",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/register",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "stats",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/stats",
+            "id": "/aws/lambda/stats",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/stats",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
         }
       ]
     },
@@ -878,7 +1066,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:auth",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -897,7 +1085,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:auth/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -924,8 +1112,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -955,7 +1143,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:login",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -974,7 +1162,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:login/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1001,8 +1189,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1032,7 +1220,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:logout",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1051,7 +1239,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:logout/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:34.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1078,8 +1266,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1109,7 +1297,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:register",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1128,7 +1316,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:register/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:29.000+0000",
+            "last_modified": "2024-09-17T06:04:43.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1155,8 +1343,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1186,7 +1374,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:stats",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1205,7 +1393,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:stats/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:27.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1232,8 +1420,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1270,7 +1458,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:connect",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1289,7 +1477,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:connect/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1316,8 +1504,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1356,7 +1544,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:default",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1375,7 +1563,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:default/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.000+0000",
+            "last_modified": "2024-09-17T06:04:47.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1402,8 +1590,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1434,7 +1622,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:disconnect",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1453,7 +1641,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:disconnect/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1480,8 +1668,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1512,7 +1700,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:joinGame",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1531,7 +1719,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:joinGame/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1558,8 +1746,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1590,7 +1778,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:makeMove",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1609,8 +1797,8 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:makeMove/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.193+0000",
-            "layers": null,
+            "last_modified": "2024-09-17T06:04:38.000+0000",
+            "layers": [],
             "logging_config": [
               {
                 "application_log_level": "",
@@ -1636,9 +1824,9 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
-            "tags": null,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
+            "tags": {},
             "tags_all": {},
             "timeout": 3,
             "timeouts": null,
@@ -1668,7 +1856,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:message",
-            "code_sha256": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1687,7 +1875,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:message/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-17T05:30:26.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1714,8 +1902,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "Qyg1eIPVTu0D1cXfbY3+argZTOQuk4dMpz1Ddz8QFjQ=",
-            "source_code_size": 25796256,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -2141,7 +2329,7 @@
             "content_encoding": "",
             "content_language": "",
             "content_type": "jar",
-            "etag": "c980d3c27ff3c9c510b2b94db43a1edf-5",
+            "etag": "e2efd3685120ec1c5d20ba30a3f180aa-5",
             "force_destroy": false,
             "id": "chess.jar",
             "key": "chess.jar",
@@ -2165,8 +2353,7 @@
           "dependencies": [
             "aws_s3_bucket.lambda_bucket",
             "random_pet.lambda_bucket_name"
-          ],
-          "create_before_destroy": true
+          ]
         }
       ]
     },

--- a/src/terraform/terraform.tfstate.backup
+++ b/src/terraform/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.7.5",
-  "serial": 2385,
+  "serial": 2463,
   "lineage": "2358f90d-604f-5fa9-5f28-fc15441c7608",
   "outputs": {},
   "resources": [
@@ -15,16 +15,16 @@
           "schema_version": 0,
           "attributes": {
             "canary_settings": [],
-            "created_date": "2024-09-15T07:49:40Z",
+            "created_date": "2024-09-17T05:30:24Z",
             "description": "",
             "execution_arn": "arn:aws:execute-api:us-east-1:891377152062:y6xko0b5hj/",
-            "id": "by0fcj",
+            "id": "93ge03",
             "invoke_url": "https://y6xko0b5hj.execute-api.us-east-1.amazonaws.com/",
             "rest_api_id": "y6xko0b5hj",
             "stage_description": null,
             "stage_name": null,
             "triggers": {
-              "redeployment": "c74c064f5b52012f9ebe3fbbd42b41186129f83d"
+              "redeployment": "09e1104dd56efc32a55e83adc2e075b2e9c63227"
             },
             "variables": null
           },
@@ -49,7 +49,7 @@
             "api_key_source": "HEADER",
             "arn": "arn:aws:apigateway:us-east-1::/restapis/y6xko0b5hj",
             "binary_media_types": [],
-            "body": "openapi: 3.0.0\ninfo:\n  title: Chess Cloud API\n  description: API for our React-Nave mobile app\n  version: 1.0.0\nservers:\n- url: /\npaths:\n  /login:\n    post:\n      summary: Login to the system\n      description: \"Logs a user into the system, providing a session token.\"\n      requestBody:\n        content:\n          application/json:\n            schema:\n              $ref: '#/components/schemas/LoginRequestBody'\n        required: true\n      responses:\n        \"200\":\n          description: Login successful\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/LoginResponse'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"401\":\n          description: Unauthorized\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:login/invocations\"\n        default:\n          statusCode: \"200\"\n          responseParameters:\n            method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n            method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n            method.response.header.Access-Control-Allow-Origin: '''*'''\n          responseTemplates:\n            application/json: {}\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\n  /logout:\n    post:\n      summary: Logout\n      description: Logout of the app\n      parameters:\n      - name: Authorization\n        in: header\n        description: session token\n        required: true\n        schema:\n          type: string\n      - name: userId\n        in: header\n        required: true\n        schema:\n          type: string\n      responses:\n        \"200\":\n          description: OK\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      security:\n      - bearerAuth: []\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:logout/invocations\"\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: '''*'''\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\n  /register:\n    post:\n      summary: Register to the system\n      description: \"Registers a user into the system, providing a session token.\"\n      requestBody:\n        content:\n          application/json:\n            schema:\n              $ref: '#/components/schemas/RegisterRequestBody'\n        required: true\n      responses:\n        \"200\":\n          description: OK\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"409\":\n          description: Conflict\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:register/invocations\"\n        default:\n          statusCode: \"200\"\n          responseParameters:\n            method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n            method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n            method.response.header.Access-Control-Allow-Origin: '''*'''\n          responseTemplates:\n            application/json: {}\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\n  /stats:\n    post:\n      summary: stats\n      description: post win/loss/draw/rating\n      parameters:\n      - name: Authorization\n        in: header\n        description: session token\n        required: true\n        schema:\n          type: string\n      - name: userId\n        in: header\n        required: true\n        schema:\n          type: string\n      - name: gamemode\n        in: query\n        description: Specific game mode to retrieve stats for (optional)\n        required: false\n        schema:\n          type: string\n      responses:\n        \"200\":\n          description: Post Stats Successful\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GamemodeStats'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      security:\n      - bearerAuth: []\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:stats/invocations\"\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: '''*'''\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\ncomponents:\n  schemas:\n    LoginRequestBody:\n      required:\n      - email\n      - password\n      type: object\n      properties:\n        email:\n          type: string\n          description: The user's email address\n          format: email\n        password:\n          type: string\n          description: The user's password\n    LoginResponse:\n      type: object\n      properties:\n        token:\n          type: string\n          example: 9dd1561d-e3ea-419b-a394-5ca2fbad058b\n        user:\n          $ref: '#/components/schemas/User'\n    GeneralResponseModel:\n      type: object\n      properties:\n        message:\n          type: string\n          example: Message\n    RegisterRequestBody:\n      required:\n      - email\n      - password\n      - username\n      type: object\n      properties:\n        email:\n          type: string\n          description: The user's email address\n          format: email\n        username:\n          type: string\n          description: User's username(non-unique)\n        password:\n          type: string\n          description: The user's password\n    GamemodeStats:\n      type: object\n      additionalProperties:\n        $ref: '#/components/schemas/Stats'\n      description: Stats for one or all tracked game modes\n    Stats:\n      required:\n      - draws\n      - losses\n      - rating\n      - wins\n      type: object\n      properties:\n        wins:\n          type: integer\n          example: 1\n        losses:\n          type: integer\n          example: 2\n        draws:\n          type: integer\n          example: 3\n        rating:\n          type: integer\n          example: 987\n    User:\n      type: object\n      properties:\n        id:\n          type: string\n          example: foo-id\n        email:\n          type: string\n          example: fake@gmail.com\n        username:\n          type: string\n          example: foo-username\n  responses:\n    \"400\":\n      description: Bad Request\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n    \"401\":\n      description: Unauthorized\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n    \"200\":\n      description: OK\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n    \"409\":\n      description: Conflict\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n  parameters:\n    authHeader:\n      name: Authorization\n      in: header\n      description: session token\n      required: true\n      schema:\n        type: string\n    userId:\n      name: userId\n      in: header\n      required: true\n      schema:\n        type: string\n  securitySchemes:\n    bearerAuth:\n      type: apiKey\n      name: Unused\n      in: header\n      scheme: bearer\n      bearerFormat: Session Token\n      x-amazon-apigateway-authtype: custom\n      x-amazon-apigateway-authorizer:\n        type: REQUEST\n        authorizerUri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:auth/invocations\"\n        identityValidationExpression: \"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$\"\n        authorizerResultTtlInSeconds: 300\n        identitySource: \"method.request.header.Authorization,method.request.header.userId\"\nx-amazon-apigateway-gateway-responses:\n  DEFAULT_4XX:\n    responseParameters:\n      gatewayresponse.header.Access-Control-Allow-Origin: '''*'''\n      gatewayresponse.header.Access-Control-Allow-Methods: \"'GET,POST,OPTIONS'\"\n      gatewayresponse.header.Access-Control-Allow-Headers: \"'Content-Type,Authorization'\"\n    responseTemplates:\n      application/json: \"{}\"\n  DEFAULT_5XX:\n    responseParameters:\n      gatewayresponse.header.Access-Control-Allow-Origin: '''*'''\n      gatewayresponse.header.Access-Control-Allow-Methods: \"'GET,POST,OPTIONS'\"\n      gatewayresponse.header.Access-Control-Allow-Headers: \"'Content-Type,Authorization'\"\n    responseTemplates:\n      application/json: \"{}\"\n",
+            "body": "openapi: 3.0.0\ninfo:\n  title: Chess Cloud API\n  description: API for our React-Nave mobile app\n  version: 1.0.0\nservers:\n- url: /\npaths:\n  /login:\n    post:\n      summary: Login to the system\n      description: \"Logs a user into the system, providing a session token.\"\n      requestBody:\n        content:\n          application/json:\n            schema:\n              $ref: '#/components/schemas/LoginRequestBody'\n        required: true\n      responses:\n        \"200\":\n          description: Login successful\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/LoginResponse'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"401\":\n          description: Unauthorized\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:login/invocations\"\n        default:\n          statusCode: \"200\"\n          responseParameters:\n            method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n            method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n            method.response.header.Access-Control-Allow-Origin: '''*'''\n          responseTemplates:\n            application/json: {}\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\n  /logout:\n    post:\n      summary: Logout\n      description: Logout of the app\n      parameters:\n      - name: Authorization\n        in: header\n        description: session token\n        required: true\n        schema:\n          type: string\n      - name: userId\n        in: header\n        required: true\n        schema:\n          type: string\n      responses:\n        \"200\":\n          description: OK\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      security:\n      - bearerAuth: []\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:logout/invocations\"\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: '''*'''\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\n  /register:\n    post:\n      summary: Register to the system\n      description: \"Registers a user into the system, providing a session token.\"\n      requestBody:\n        content:\n          application/json:\n            schema:\n              $ref: '#/components/schemas/RegisterRequestBody'\n        required: true\n      responses:\n        \"200\":\n          description: OK\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n        \"409\":\n          description: Conflict\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:register/invocations\"\n        default:\n          statusCode: \"200\"\n          responseParameters:\n            method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n            method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n            method.response.header.Access-Control-Allow-Origin: '''*'''\n          responseTemplates:\n            application/json: {}\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: \"'Content-Type,X-Amz-Date,Authorization,X-Api-Key'\"\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\n  /stats:\n    post:\n      summary: stats\n      description: post win/loss/draw/rating\n      parameters:\n      - name: Authorization\n        in: header\n        description: session token\n        required: true\n        schema:\n          type: string\n      - name: userId\n        in: header\n        required: true\n        schema:\n          type: string\n      - name: gamemode\n        in: query\n        description: Specific game mode to retrieve stats for (optional)\n        required: false\n        schema:\n          type: string\n      responses:\n        \"200\":\n          description: Post Stats Successful\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GamemodeStats'\n        \"400\":\n          description: Bad Request\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content:\n            application/json:\n              schema:\n                $ref: '#/components/schemas/GeneralResponseModel'\n      security:\n      - bearerAuth: []\n      x-amazon-apigateway-integration:\n        type: aws_proxy\n        httpMethod: POST\n        uri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:stats/invocations\"\n    options:\n      tags:\n      - CORS\n      summary: CORS support\n      description: Enable CORS by returning correct headers\n      responses:\n        \"200\":\n          description: Default response for CORS method\n          headers:\n            Access-Control-Allow-Origin:\n              schema:\n                type: string\n            Access-Control-Allow-Methods:\n              schema:\n                type: string\n            Access-Control-Allow-Headers:\n              schema:\n                type: string\n          content: {}\n      x-amazon-apigateway-integration:\n        type: mock\n        requestTemplates:\n          application/json: \"{\\\"statusCode\\\": 200}\"\n        responses:\n          default:\n            statusCode: \"200\"\n            responseParameters:\n              method.response.header.Access-Control-Allow-Headers: '''*'''\n              method.response.header.Access-Control-Allow-Methods: \"'POST,OPTIONS'\"\n              method.response.header.Access-Control-Allow-Origin: '''*'''\n              responseTemplates:\n                application/json: {}\ncomponents:\n  schemas:\n    LoginRequestBody:\n      required:\n      - email\n      - password\n      type: object\n      properties:\n        email:\n          type: string\n          description: The user's email address\n          format: email\n        password:\n          type: string\n          description: The user's password\n    LoginResponse:\n      type: object\n      properties:\n        token:\n          type: string\n          example: 9dd1561d-e3ea-419b-a394-5ca2fbad058b\n        user:\n          $ref: '#/components/schemas/User'\n    GeneralResponseModel:\n      type: object\n      properties:\n        message:\n          type: string\n          example: Message\n    RegisterRequestBody:\n      required:\n      - email\n      - password\n      - username\n      type: object\n      properties:\n        email:\n          type: string\n          description: The user's email address\n          format: email\n        username:\n          type: string\n          description: User's username(non-unique)\n        password:\n          type: string\n          description: The user's password\n    GamemodeStats:\n      type: object\n      properties: {}\n      description: Stats for one or all tracked game modes\n    User:\n      type: object\n      properties:\n        id:\n          type: string\n          example: foo-id\n        email:\n          type: string\n          example: fake@gmail.com\n        username:\n          type: string\n          example: foo-username\n  responses:\n    \"400\":\n      description: Bad Request\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n    \"401\":\n      description: Unauthorized\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n    \"200\":\n      description: OK\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n    \"409\":\n      description: Conflict\n      headers:\n        Access-Control-Allow-Origin:\n          schema:\n            type: string\n        Access-Control-Allow-Methods:\n          schema:\n            type: string\n        Access-Control-Allow-Headers:\n          schema:\n            type: string\n      content:\n        application/json:\n          schema:\n            $ref: '#/components/schemas/GeneralResponseModel'\n  parameters:\n    authHeader:\n      name: Authorization\n      in: header\n      description: session token\n      required: true\n      schema:\n        type: string\n    userId:\n      name: userId\n      in: header\n      required: true\n      schema:\n        type: string\n  securitySchemes:\n    bearerAuth:\n      type: apiKey\n      name: Unused\n      in: header\n      scheme: bearer\n      bearerFormat: Session Token\n      x-amazon-apigateway-authtype: custom\n      x-amazon-apigateway-authorizer:\n        type: REQUEST\n        authorizerUri: \"arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:auth/invocations\"\n        identityValidationExpression: \"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$\"\n        authorizerResultTtlInSeconds: 300\n        identitySource: \"method.request.header.Authorization,method.request.header.userId\"\nx-amazon-apigateway-gateway-responses:\n  DEFAULT_4XX:\n    responseParameters:\n      gatewayresponse.header.Access-Control-Allow-Origin: '''*'''\n      gatewayresponse.header.Access-Control-Allow-Methods: \"'GET,POST,OPTIONS'\"\n      gatewayresponse.header.Access-Control-Allow-Headers: \"'Content-Type,Authorization'\"\n    responseTemplates:\n      application/json: \"{}\"\n  DEFAULT_5XX:\n    responseParameters:\n      gatewayresponse.header.Access-Control-Allow-Origin: '''*'''\n      gatewayresponse.header.Access-Control-Allow-Methods: \"'GET,POST,OPTIONS'\"\n      gatewayresponse.header.Access-Control-Allow-Headers: \"'Content-Type,Authorization'\"\n    responseTemplates:\n      application/json: \"{}\"\n",
             "created_date": "2024-08-25T23:25:27Z",
             "description": "API for our React-Nave mobile app",
             "disable_execute_api_endpoint": false,
@@ -94,7 +94,7 @@
             "cache_cluster_size": "",
             "canary_settings": [],
             "client_certificate_id": "",
-            "deployment_id": "by0fcj",
+            "deployment_id": "93ge03",
             "description": "",
             "documentation_version": "",
             "execution_arn": "arn:aws:execute-api:us-east-1:891377152062:y6xko0b5hj/dev",
@@ -205,9 +205,9 @@
             "api_id": "b1bgyojlzj",
             "auto_deployed": false,
             "description": "",
-            "id": "361mu7",
+            "id": "ivohvu",
             "triggers": {
-              "redeployment": "362fa5926bca2ae7c3653643282a40f190e07d74"
+              "redeployment": "43dfb235846b8f933909e82241fbd3f0607de06d"
             }
           },
           "sensitive_attributes": [],
@@ -369,6 +369,43 @@
             "integration_subtype": "",
             "integration_type": "AWS_PROXY",
             "integration_uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:joinGame/invocations",
+            "passthrough_behavior": "WHEN_NO_MATCH",
+            "payload_format_version": "1.0",
+            "request_parameters": {},
+            "request_templates": {},
+            "response_parameters": [],
+            "template_selection_expression": "",
+            "timeout_milliseconds": 29000,
+            "tls_config": []
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_apigatewayv2_api.chess-websocket",
+            "aws_iam_role.iam_role_for_lambda",
+            "aws_lambda_function.websocket_lambda_functions",
+            "aws_s3_bucket.lambda_bucket",
+            "aws_s3_object.project_jar",
+            "random_pet.lambda_bucket_name"
+          ],
+          "create_before_destroy": true
+        },
+        {
+          "index_key": "makeMove",
+          "schema_version": 0,
+          "attributes": {
+            "api_id": "b1bgyojlzj",
+            "connection_id": "",
+            "connection_type": "INTERNET",
+            "content_handling_strategy": "",
+            "credentials_arn": "",
+            "description": "Lambda example",
+            "id": "n18c64n",
+            "integration_method": "POST",
+            "integration_response_selection_expression": "",
+            "integration_subtype": "",
+            "integration_type": "AWS_PROXY",
+            "integration_uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:makeMove/invocations",
             "passthrough_behavior": "WHEN_NO_MATCH",
             "payload_format_version": "1.0",
             "request_parameters": {},
@@ -572,6 +609,37 @@
           "create_before_destroy": true
         },
         {
+          "index_key": "makeMove",
+          "schema_version": 0,
+          "attributes": {
+            "api_id": "b1bgyojlzj",
+            "api_key_required": false,
+            "authorization_scopes": [],
+            "authorization_type": "NONE",
+            "authorizer_id": "",
+            "id": "viwhs4a",
+            "model_selection_expression": "",
+            "operation_name": "",
+            "request_models": {},
+            "request_parameter": [],
+            "route_key": "makeMove",
+            "route_response_selection_expression": "",
+            "target": "integrations/n18c64n"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_apigatewayv2_api.chess-websocket",
+            "aws_apigatewayv2_integration.integrations",
+            "aws_iam_role.iam_role_for_lambda",
+            "aws_lambda_function.websocket_lambda_functions",
+            "aws_s3_bucket.lambda_bucket",
+            "aws_s3_object.project_jar",
+            "random_pet.lambda_bucket_name"
+          ],
+          "create_before_destroy": true
+        },
+        {
           "index_key": "message",
           "schema_version": 0,
           "attributes": {
@@ -658,7 +726,7 @@
                 "throttling_rate_limit": 2
               }
             ],
-            "deployment_id": "361mu7",
+            "deployment_id": "ivohvu",
             "description": "",
             "execution_arn": "arn:aws:execute-api:us-east-1:891377152062:b1bgyojlzj/dev",
             "id": "dev",
@@ -685,6 +753,194 @@
             "aws_s3_object.project_jar",
             "random_pet.lambda_bucket_name"
           ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_cloudwatch_log_group",
+      "name": "retention_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": "auth",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/auth",
+            "id": "/aws/lambda/auth",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/auth",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/default",
+            "id": "/aws/lambda/default",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/default",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "disconnect",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/disconnect",
+            "id": "/aws/lambda/disconnect",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/disconnect",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "joinGame",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/joinGame",
+            "id": "/aws/lambda/joinGame",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/joinGame",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "login",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/login",
+            "id": "/aws/lambda/login",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/login",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "logout",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/logout",
+            "id": "/aws/lambda/logout",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/logout",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "makeMove",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/makeMove",
+            "id": "/aws/lambda/makeMove",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/makeMove",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "message",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/message",
+            "id": "/aws/lambda/message",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/message",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "register",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/register",
+            "id": "/aws/lambda/register",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/register",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": "stats",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:891377152062:log-group:/aws/lambda/stats",
+            "id": "/aws/lambda/stats",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "/aws/lambda/stats",
+            "name_prefix": "",
+            "retention_in_days": 3,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
         }
       ]
     },
@@ -810,7 +1066,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:auth",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -829,7 +1085,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:auth/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:10.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -856,8 +1112,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -887,7 +1143,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:login",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -906,7 +1162,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:login/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -933,8 +1189,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -964,7 +1220,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:logout",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -983,7 +1239,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:logout/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1010,8 +1266,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1041,7 +1297,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:register",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1060,7 +1316,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:register/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:43.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1087,8 +1343,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1118,7 +1374,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:stats",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1137,7 +1393,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:stats/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1164,8 +1420,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1202,7 +1458,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:connect",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1221,7 +1477,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:connect/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1248,8 +1504,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1269,7 +1525,8 @@
             "aws_s3_bucket.lambda_bucket",
             "aws_s3_object.project_jar",
             "random_pet.lambda_bucket_name"
-          ]
+          ],
+          "create_before_destroy": true
         }
       ]
     },
@@ -1287,7 +1544,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:default",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1306,7 +1563,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:default/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:47.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1333,8 +1590,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1354,7 +1611,8 @@
             "aws_s3_bucket.lambda_bucket",
             "aws_s3_object.project_jar",
             "random_pet.lambda_bucket_name"
-          ]
+          ],
+          "create_before_destroy": true
         },
         {
           "index_key": "disconnect",
@@ -1364,7 +1622,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:disconnect",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1383,7 +1641,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:disconnect/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1410,8 +1668,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1431,7 +1689,8 @@
             "aws_s3_bucket.lambda_bucket",
             "aws_s3_object.project_jar",
             "random_pet.lambda_bucket_name"
-          ]
+          ],
+          "create_before_destroy": true
         },
         {
           "index_key": "joinGame",
@@ -1441,7 +1700,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:joinGame",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1460,7 +1719,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:joinGame/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1487,8 +1746,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1508,7 +1767,86 @@
             "aws_s3_bucket.lambda_bucket",
             "aws_s3_object.project_jar",
             "random_pet.lambda_bucket_name"
-          ]
+          ],
+          "create_before_destroy": true
+        },
+        {
+          "index_key": "makeMove",
+          "schema_version": 0,
+          "attributes": {
+            "architectures": [
+              "x86_64"
+            ],
+            "arn": "arn:aws:lambda:us-east-1:891377152062:function:makeMove",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "code_signing_config_arn": "",
+            "dead_letter_config": [],
+            "description": "",
+            "environment": [],
+            "ephemeral_storage": [
+              {
+                "size": 512
+              }
+            ],
+            "file_system_config": [],
+            "filename": null,
+            "function_name": "makeMove",
+            "handler": "org.example.handlers.makeMove.MakeMoveHandler::handleRequest",
+            "id": "makeMove",
+            "image_config": [],
+            "image_uri": "",
+            "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:makeMove/invocations",
+            "kms_key_arn": "",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
+            "layers": [],
+            "logging_config": [
+              {
+                "application_log_level": "",
+                "log_format": "Text",
+                "log_group": "/aws/lambda/makeMove",
+                "system_log_level": ""
+              }
+            ],
+            "memory_size": 1536,
+            "package_type": "Zip",
+            "publish": false,
+            "qualified_arn": "arn:aws:lambda:us-east-1:891377152062:function:makeMove:$LATEST",
+            "qualified_invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:makeMove:$LATEST/invocations",
+            "replace_security_groups_on_destroy": null,
+            "replacement_security_group_ids": null,
+            "reserved_concurrent_executions": -1,
+            "role": "arn:aws:iam::891377152062:role/lambda_invoke_role",
+            "runtime": "java17",
+            "s3_bucket": "lambda-mutual-wahoo",
+            "s3_key": "chess.jar",
+            "s3_object_version": null,
+            "signing_job_arn": "",
+            "signing_profile_version_arn": "",
+            "skip_destroy": false,
+            "snap_start": [],
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
+            "tags": {},
+            "tags_all": {},
+            "timeout": 3,
+            "timeouts": null,
+            "tracing_config": [
+              {
+                "mode": "PassThrough"
+              }
+            ],
+            "version": "$LATEST",
+            "vpc_config": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "aws_iam_role.iam_role_for_lambda",
+            "aws_s3_bucket.lambda_bucket",
+            "aws_s3_object.project_jar",
+            "random_pet.lambda_bucket_name"
+          ],
+          "create_before_destroy": true
         },
         {
           "index_key": "message",
@@ -1518,7 +1856,7 @@
               "x86_64"
             ],
             "arn": "arn:aws:lambda:us-east-1:891377152062:function:message",
-            "code_sha256": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
+            "code_sha256": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
             "code_signing_config_arn": "",
             "dead_letter_config": [],
             "description": "",
@@ -1537,7 +1875,7 @@
             "image_uri": "",
             "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:891377152062:function:message/invocations",
             "kms_key_arn": "",
-            "last_modified": "2024-09-15T10:31:07.000+0000",
+            "last_modified": "2024-09-17T06:04:38.000+0000",
             "layers": [],
             "logging_config": [
               {
@@ -1564,8 +1902,8 @@
             "signing_profile_version_arn": "",
             "skip_destroy": false,
             "snap_start": [],
-            "source_code_hash": "E6Hy3TD8ajHZrxIsjZNmD+IkPgZFecCjTlT0VUGjHl0=",
-            "source_code_size": 25645895,
+            "source_code_hash": "iZyFpMAeX7D2lc9inzcCjczl58M4fB3ouFG0jipeqm8=",
+            "source_code_size": 25796062,
             "tags": {},
             "tags_all": {},
             "timeout": 3,
@@ -1585,7 +1923,8 @@
             "aws_s3_bucket.lambda_bucket",
             "aws_s3_object.project_jar",
             "random_pet.lambda_bucket_name"
-          ]
+          ],
+          "create_before_destroy": true
         }
       ]
     },
@@ -1818,6 +2157,29 @@
           ]
         },
         {
+          "index_key": "makeMove",
+          "schema_version": 0,
+          "attributes": {
+            "action": "lambda:InvokeFunction",
+            "event_source_token": null,
+            "function_name": "makeMove",
+            "function_url_auth_type": null,
+            "id": "terraform-20240917053024238700000001",
+            "principal": "apigateway.amazonaws.com",
+            "principal_org_id": null,
+            "qualifier": "",
+            "source_account": null,
+            "source_arn": "arn:aws:execute-api:us-east-1:891377152062:b1bgyojlzj/dev/makeMove",
+            "statement_id": "terraform-20240917053024238700000001",
+            "statement_id_prefix": "terraform-"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_apigatewayv2_api.chess-websocket"
+          ]
+        },
+        {
           "index_key": "message",
           "schema_version": 0,
           "attributes": {
@@ -1967,7 +2329,7 @@
             "content_encoding": "",
             "content_language": "",
             "content_type": "jar",
-            "etag": "db1bca4608148bdf2572794aa6e05f7b-5",
+            "etag": "e2efd3685120ec1c5d20ba30a3f180aa-5",
             "force_destroy": false,
             "id": "chess.jar",
             "key": "chess.jar",


### PR DESCRIPTION
… after creation

### Summary

This PR will create a log retention policy -- every event in every cloudwatch log group will automatically be deleted 3 days after the event log's creation

### Checklist

- [x] Wrote any required new unit and integration tests
- [x] Passed all unit and integration tests :feelsgood:
- [x] Run Google formatter within IDE
- [x] PR title and commit messages are easy for others to follow :doughnut:
