### PR TITLE
Refactor OfferDraw endpoint and small bug fixes

### DIFF
--- a/src/main/java/org/example/entities/game/Game.java
+++ b/src/main/java/org/example/entities/game/Game.java
@@ -79,6 +79,11 @@ public class Game extends BaseGame<Player> {
     this.players.add(player2);
   }
 
+  public boolean containsConnectionId(String connectionId) {
+    return this.players.stream()
+        .anyMatch(player -> player.getConnectionId().equals(connectionId));
+  }
+
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("Game{");

--- a/src/main/java/org/example/entities/game/GameDbService.java
+++ b/src/main/java/org/example/entities/game/GameDbService.java
@@ -35,12 +35,7 @@ public class GameDbService {
   }
 
   public boolean isConnectionIdInGame(String gameId, String connectionId) throws NotFound {
-    Game game = get(gameId);
-
-    for (Player player : game.getPlayers())
-      if (player.getConnectionId().equals(connectionId)) return true;
-
-    return false;
+    return get(gameId).containsConnectionId(connectionId);
   }
 
   public void deleteGame(String gameId) {

--- a/src/main/java/org/example/enums/OfferDrawAction.java
+++ b/src/main/java/org/example/enums/OfferDrawAction.java
@@ -1,0 +1,8 @@
+package org.example.enums;
+
+public enum OfferDrawAction {
+  OFFER,
+  CANCEL,
+  DENY,
+  ACCEPT
+}

--- a/src/main/java/org/example/enums/WebsocketResponseAction.java
+++ b/src/main/java/org/example/enums/WebsocketResponseAction.java
@@ -1,6 +1,6 @@
 package org.example.enums;
 
-public enum Action {
+public enum WebsocketResponseAction {
   GAME_START,
   GAME_CREATED,
   GAME_OVER,

--- a/src/main/java/org/example/handlers/websocket/JoinGameHandler.java
+++ b/src/main/java/org/example/handlers/websocket/JoinGameHandler.java
@@ -13,7 +13,7 @@ import org.example.entities.game.Game;
 import org.example.entities.player.Player;
 import org.example.entities.stats.Stats;
 import org.example.entities.user.User;
-import org.example.enums.Action;
+import org.example.enums.WebsocketResponseAction;
 import org.example.enums.GameMode;
 import org.example.exceptions.NotFound;
 import org.example.models.requests.JoinGameRequest;
@@ -65,7 +65,7 @@ public class JoinGameHandler
               .message("No user matches userId")
               .build();
       SocketResponseBody<GameStartedMessageData> responseBody =
-          new SocketResponseBody<>(Action.GAME_CREATED, data);
+          new SocketResponseBody<>(WebsocketResponseAction.GAME_CREATED, data);
       emitter.sendMessage(connectionId, responseBody.toJSON());
 
       return makeWebsocketResponse(StatusCodes.UNAUTHORIZED, "No user matches userId");
@@ -79,7 +79,7 @@ public class JoinGameHandler
               .message("User doesn't have entry in Stats collection")
               .build();
       SocketResponseBody<GameStartedMessageData> responseBody =
-          new SocketResponseBody<>(Action.GAME_CREATED, data);
+          new SocketResponseBody<>(WebsocketResponseAction.GAME_CREATED, data);
       emitter.sendMessage(connectionId, responseBody.toJSON());
 
       return makeWebsocketResponse(
@@ -94,7 +94,7 @@ public class JoinGameHandler
               .message("You are already in 1 game.")
               .build();
       SocketResponseBody<GameStartedMessageData> responseBody =
-          new SocketResponseBody<>(Action.GAME_CREATED, data);
+          new SocketResponseBody<>(WebsocketResponseAction.GAME_CREATED, data);
       emitter.sendMessage(connectionId, responseBody.toJSON());
 
       return makeWebsocketResponse(StatusCodes.FORBIDDEN, "You are already in 1 game.");
@@ -132,7 +132,7 @@ public class JoinGameHandler
       body = newGame.toResponseJson();
       GameCreatedMessageData messageData = new GameCreatedMessageData();
       SocketResponseBody<GameCreatedMessageData> responseBody =
-          new SocketResponseBody<>(Action.GAME_CREATED, messageData);
+          new SocketResponseBody<>(WebsocketResponseAction.GAME_CREATED, messageData);
       emitter.sendMessage(connectionId, responseBody.toJSON());
     } else {
       // Pending game exists for the requested time control
@@ -147,7 +147,7 @@ public class JoinGameHandler
                 .isSuccess(false)
                 .message("Error in setting up game.")
                 .build();
-        responseBody = new SocketResponseBody<>(Action.GAME_START, data);
+        responseBody = new SocketResponseBody<>(WebsocketResponseAction.GAME_START, data);
         emitter.sendMessages(
             game.getPlayers().get(0).getConnectionId(),
             game.getPlayers().get(1).getConnectionId(),
@@ -160,7 +160,7 @@ public class JoinGameHandler
 
       // Notify both players that the game is starting
       data = new GameStartedMessageData(game);
-      responseBody = new SocketResponseBody<>(Action.GAME_START, data);
+      responseBody = new SocketResponseBody<>(WebsocketResponseAction.GAME_START, data);
       String resJson = responseBody.toJSON();
       emitter.sendMessages(
           game.getPlayers().get(0).getConnectionId(),

--- a/src/main/java/org/example/handlers/websocket/MakeMoveHandler.java
+++ b/src/main/java/org/example/handlers/websocket/MakeMoveHandler.java
@@ -13,7 +13,7 @@ import java.util.Date;
 import java.util.Map;
 import org.example.constants.StatusCodes;
 import org.example.entities.game.Game;
-import org.example.enums.Action;
+import org.example.enums.WebsocketResponseAction;
 import org.example.exceptions.*;
 import org.example.models.requests.MakeMoveRequest;
 import org.example.models.responses.websocket.MakeMoveMessageData;
@@ -70,7 +70,7 @@ public class MakeMoveHandler
           MakeMoveMessageData.builder().isSuccess(false).message(e.getMessage()).build();
 
       SocketResponseBody<MakeMoveMessageData> responseBody =
-          new SocketResponseBody<>(Action.MOVE_MADE, data);
+          new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
       socketMessenger.sendMessage(connectionId, responseBody.toJSON());
       logger.log("error loading game", LogLevel.ERROR);
 
@@ -82,7 +82,7 @@ public class MakeMoveHandler
           MakeMoveMessageData.builder().isSuccess(false).message("It is not your turn.").build();
 
       SocketResponseBody<MakeMoveMessageData> responseBody =
-          new SocketResponseBody<>(Action.MOVE_MADE, data);
+          new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
       socketMessenger.sendMessage(connectionId, responseBody.toJSON());
       logger.log("It is not your turn.", LogLevel.ERROR);
       return makeWebsocketResponse(StatusCodes.FORBIDDEN, "It is not your turn.");
@@ -94,7 +94,7 @@ public class MakeMoveHandler
           MakeMoveMessageData.builder().isSuccess(false).message("Game missing FEN").build();
 
       SocketResponseBody<MakeMoveMessageData> responseBody =
-          new SocketResponseBody<>(Action.MOVE_MADE, data);
+          new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
       socketMessenger.sendMessage(connectionId, responseBody.toJSON());
       logger.log("Game missing fen", LogLevel.FATAL);
       return makeWebsocketResponse(StatusCodes.INTERNAL_SERVER_ERROR, "Game missing FEN");
@@ -108,7 +108,7 @@ public class MakeMoveHandler
           MakeMoveMessageData.builder().isSuccess(false).message(e.getMessage()).build();
 
       SocketResponseBody<MakeMoveMessageData> responseBody =
-          new SocketResponseBody<>(Action.MOVE_MADE, data);
+          new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
       socketMessenger.sendMessage(connectionId, responseBody.toJSON());
       logger.log(e.getMessage(), LogLevel.ERROR);
       return e.makeWebsocketResponse();
@@ -124,7 +124,7 @@ public class MakeMoveHandler
             remainingTimes.get("white"),
             remainingTimes.get("black"));
     SocketResponseBody<MakeMoveMessageData> responseBody =
-        new SocketResponseBody<>(Action.MOVE_MADE, data);
+        new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
     socketMessenger.sendMessages(connectionIds[0], connectionIds[1], responseBody.toJSON());
 
     return makeWebsocketResponse(StatusCodes.OK, responseBody.toJSON());

--- a/src/main/java/org/example/handlers/websocket/MessageHandler.java
+++ b/src/main/java/org/example/handlers/websocket/MessageHandler.java
@@ -10,7 +10,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketRespons
 import com.google.gson.Gson;
 import org.example.constants.StatusCodes;
 import org.example.entities.game.Game;
-import org.example.enums.Action;
+import org.example.enums.WebsocketResponseAction;
 import org.example.enums.GameStatus;
 import org.example.models.requests.MessageRequest;
 import org.example.models.responses.websocket.ChatMessageData;
@@ -61,19 +61,19 @@ public class MessageHandler
       LambdaLogger logger = context.getLogger();
       logger.log(e.getMessage());
       data = ChatMessageData.builder().isSuccess(false).message("game not found").build();
-      responseBody = new SocketResponseBody<>(Action.CHAT_MESSAGE, data);
+      responseBody = new SocketResponseBody<>(WebsocketResponseAction.CHAT_MESSAGE, data);
       emitter.sendMessage(connectionId, responseBody.toJSON());
       return makeWebsocketResponse(StatusCodes.NOT_FOUND, "Game not found");
     }
     if (!game.getGameStatus().equals(GameStatus.ONGOING) || game.getPlayers().size() != 2) {
       data =
           ChatMessageData.builder().isSuccess(false).message("Cannot find chat recipient.").build();
-      responseBody = new SocketResponseBody<>(Action.CHAT_MESSAGE, data);
+      responseBody = new SocketResponseBody<>(WebsocketResponseAction.CHAT_MESSAGE, data);
       emitter.sendMessage(connectionId, responseBody.toJSON());
       return makeWebsocketResponse(StatusCodes.BAD_REQUEST, "Cannot find chat recipient.");
     }
     data = new ChatMessageData(username + ": " + chatMessage);
-    responseBody = new SocketResponseBody<>(Action.CHAT_MESSAGE, data);
+    responseBody = new SocketResponseBody<>(WebsocketResponseAction.CHAT_MESSAGE, data);
     emitter.sendMessages(
         game.getPlayers().get(0).getConnectionId(),
         game.getPlayers().get(1).getConnectionId(),

--- a/src/main/java/org/example/handlers/websocket/offerDraw/OfferDrawHandler.java
+++ b/src/main/java/org/example/handlers/websocket/offerDraw/OfferDrawHandler.java
@@ -41,41 +41,12 @@ public class OfferDrawHandler
       return makeWebsocketResponse(StatusCodes.BAD_REQUEST, "Missing argument(s)");
     }
 
-    // Check connection ID is part of the game
     String connectionId = event.getRequestContext().getConnectionId();
-    try {
-      if (!offerDrawService.isValidConnectionId(request.gameId(), connectionId))
-        throw new Unauthorized("Your connection ID is not bound to this game");
-    } catch (StatusCodeException e) {
-      messenger.sendMessage(connectionId, e.getMessage());
-      return e.makeWebsocketResponse();
-    }
 
     // Switch on Draw action
     String responseMessage;
     try {
-      // TODO: basic implementation. Maybe make an Enum, then add it to OfferDrawRequest request
-      // body too
-      switch (request.action().toLowerCase()) {
-        case "offer" -> {
-          offerDrawService.offerDraw(request.gameId(), connectionId);
-          responseMessage = "Successfully offered a draw";
-        }
-        case "cancel" -> {
-          offerDrawService.cancelDraw(request.gameId(), connectionId);
-          responseMessage = "Cancelled draw offer";
-        }
-        case "deny" -> {
-          offerDrawService.denyDraw(request.gameId(), connectionId);
-          responseMessage = "Draw denied";
-        }
-        case "accept" -> {
-          offerDrawService.acceptDraw(request.gameId(), connectionId);
-          responseMessage = "Draw accepted";
-        }
-        // Unknown action
-        default -> throw new BadRequest("Invalid draw argument");
-      }
+      responseMessage = offerDrawService.performDrawAction(request.drawAction(), request.gameId(), connectionId);
     } catch (StatusCodeException e) {
       messenger.sendMessage(connectionId, e.getMessage());
       return e.makeWebsocketResponse();

--- a/src/main/java/org/example/handlers/websocket/offerDraw/OfferDrawService.java
+++ b/src/main/java/org/example/handlers/websocket/offerDraw/OfferDrawService.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 import org.example.entities.game.Game;
 import org.example.entities.game.GameDbService;
 import org.example.entities.player.Player;
+import org.example.enums.OfferDrawAction;
 import org.example.enums.WebsocketResponseAction;
 import org.example.enums.ResultReason;
 import org.example.exceptions.BadRequest;
 import org.example.exceptions.InternalServerError;
 import org.example.exceptions.NotFound;
+import org.example.exceptions.Unauthorized;
 import org.example.models.responses.websocket.SocketResponseBody;
 import org.example.models.responses.websocket.draw.CancelDrawMessageData;
 import org.example.models.responses.websocket.draw.DenyDrawMessageData;
@@ -27,14 +29,7 @@ public class OfferDrawService {
   @Builder.Default private final GameDbService gameDbService = new GameDbService();
   @Builder.Default private final SocketMessenger messenger = new SocketEmitter();
 
-  public boolean isValidConnectionId(String gameId, String connectionId) throws NotFound {
-    return gameDbService.isConnectionIdInGame(gameId, connectionId);
-  }
-
-  public void offerDraw(String gameId, String playerOfferingDrawConnectionId)
-      throws NotFound, BadRequest {
-    Game game = gameDbService.get(gameId);
-
+  private void offerDraw(Game game, String playerOfferingDrawConnectionId) throws BadRequest {
     List<Player> players = game.getPlayers();
     Player player1 = players.get(0);
     Player player2 = players.get(1);
@@ -54,7 +49,7 @@ public class OfferDrawService {
     }
 
     // Update game
-    gameDbService.put(gameId, game);
+    gameDbService.put(game.getId(), game);
 
     // Send draw offer to other player
     OfferDrawMessageData messageData = new OfferDrawMessageData();
@@ -63,10 +58,7 @@ public class OfferDrawService {
     messenger.sendMessage(opponentConnectionId, responseBody.toJSON());
   }
 
-  public void cancelDraw(String gameId, String playerCancelConnectionId)
-      throws NotFound, BadRequest {
-    Game game = gameDbService.get(gameId);
-
+  private void cancelDraw(Game game, String playerCancelConnectionId) throws BadRequest {
     List<Player> players = game.getPlayers();
     Player player1 = players.get(0);
     Player player2 = players.get(1);
@@ -88,7 +80,7 @@ public class OfferDrawService {
 
     // Update game
     playerCanceling.setWantsDraw(false);
-    gameDbService.put(gameId, game);
+    gameDbService.put(game.getId(), game);
 
     // Inform the other person offer was canceled
     CancelDrawMessageData messageData = new CancelDrawMessageData();
@@ -97,10 +89,7 @@ public class OfferDrawService {
     messenger.sendMessage(opponentConnectionId, responseBody.toJSON());
   }
 
-  public void denyDraw(String gameId, String playerDeniedDrawConnectionId)
-      throws NotFound, InternalServerError, BadRequest {
-    Game game = gameDbService.get(gameId);
-
+  private void denyDraw(Game game, String playerDeniedDrawConnectionId) throws BadRequest {
     List<Player> players = game.getPlayers();
     Player player1 = players.get(0);
     Player player2 = players.get(1);
@@ -122,7 +111,7 @@ public class OfferDrawService {
     }
 
     // Update game
-    gameDbService.put(gameId, game);
+    gameDbService.put(game.getId(), game);
 
     // Send draw deny response to other player
     DenyDrawMessageData messageData = new DenyDrawMessageData();
@@ -131,10 +120,7 @@ public class OfferDrawService {
     messenger.sendMessage(opponentConnectionId, responseBody.toJSON());
   }
 
-  public void acceptDraw(String gameId, String playerAcceptDrawConnectionId)
-      throws NotFound, InternalServerError, BadRequest {
-    Game game = gameDbService.get(gameId);
-
+  private void acceptDraw(Game game, String playerAcceptDrawConnectionId) throws InternalServerError, BadRequest {
     List<Player> players = game.getPlayers();
     Player player1 = players.get(0);
     Player player2 = players.get(1);
@@ -152,5 +138,39 @@ public class OfferDrawService {
     GameOverService service =
         new GameOverService(ResultReason.MUTUAL_DRAW, game, player1.getPlayerId(), messenger);
     service.endGame();
+  }
+
+  public String performDrawAction(OfferDrawAction action, String gameId, String connectionId) throws BadRequest, NotFound, InternalServerError, Unauthorized {
+    String responseMessage;
+
+    // Check game with ID=gameId exists
+    Game game = gameDbService.get(gameId);
+
+    // Check connection ID is part of the game
+    if (!game.containsConnectionId(connectionId))
+      throw new Unauthorized("Your connection ID is not bound to this game");
+
+    switch (action) {
+      case OfferDrawAction.OFFER -> {
+        offerDraw(game, connectionId);
+        responseMessage = "Successfully offered a draw";
+      }
+      case OfferDrawAction.CANCEL -> {
+        cancelDraw(game, connectionId);
+        responseMessage = "Cancelled draw offer";
+      }
+      case OfferDrawAction.DENY -> {
+        denyDraw(game, connectionId);
+        responseMessage = "Draw denied";
+      }
+      case OfferDrawAction.ACCEPT -> {
+        acceptDraw(game, connectionId);
+        responseMessage = "Draw accepted";
+      }
+      // Unknown action
+      default -> throw new BadRequest("Invalid value for argument 'drawAction'");
+    }
+
+    return responseMessage;
   }
 }

--- a/src/main/java/org/example/handlers/websocket/offerDraw/OfferDrawService.java
+++ b/src/main/java/org/example/handlers/websocket/offerDraw/OfferDrawService.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import org.example.entities.game.Game;
 import org.example.entities.game.GameDbService;
 import org.example.entities.player.Player;
-import org.example.enums.Action;
+import org.example.enums.WebsocketResponseAction;
 import org.example.enums.ResultReason;
 import org.example.exceptions.BadRequest;
 import org.example.exceptions.InternalServerError;
@@ -59,7 +59,7 @@ public class OfferDrawService {
     // Send draw offer to other player
     OfferDrawMessageData messageData = new OfferDrawMessageData();
     SocketResponseBody<OfferDrawMessageData> responseBody =
-        new SocketResponseBody<>(Action.DRAW_OFFER, messageData);
+        new SocketResponseBody<>(WebsocketResponseAction.DRAW_OFFER, messageData);
     messenger.sendMessage(opponentConnectionId, responseBody.toJSON());
   }
 
@@ -93,7 +93,7 @@ public class OfferDrawService {
     // Inform the other person offer was canceled
     CancelDrawMessageData messageData = new CancelDrawMessageData();
     SocketResponseBody<CancelDrawMessageData> responseBody =
-        new SocketResponseBody<>(Action.DRAW_CANCEL, messageData);
+        new SocketResponseBody<>(WebsocketResponseAction.DRAW_CANCEL, messageData);
     messenger.sendMessage(opponentConnectionId, responseBody.toJSON());
   }
 
@@ -127,7 +127,7 @@ public class OfferDrawService {
     // Send draw deny response to other player
     DenyDrawMessageData messageData = new DenyDrawMessageData();
     SocketResponseBody<DenyDrawMessageData> responseBody =
-        new SocketResponseBody<>(Action.DRAW_DENY, messageData);
+        new SocketResponseBody<>(WebsocketResponseAction.DRAW_DENY, messageData);
     messenger.sendMessage(opponentConnectionId, responseBody.toJSON());
   }
 

--- a/src/main/java/org/example/models/requests/OfferDrawRequest.java
+++ b/src/main/java/org/example/models/requests/OfferDrawRequest.java
@@ -1,3 +1,5 @@
 package org.example.models.requests;
 
-public record OfferDrawRequest(String gameId, String action) {}
+import org.example.enums.OfferDrawAction;
+
+public record OfferDrawRequest(String gameId, OfferDrawAction drawAction) {}

--- a/src/main/java/org/example/models/responses/websocket/SocketResponseBody.java
+++ b/src/main/java/org/example/models/responses/websocket/SocketResponseBody.java
@@ -3,13 +3,13 @@ package org.example.models.responses.websocket;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.enums.Action;
+import org.example.enums.WebsocketResponseAction;
 import org.example.models.responses.rest.ResponseBody;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class SocketResponseBody<T extends SocketMessageData> extends ResponseBody {
-  protected Action action;
+  protected WebsocketResponseAction websocketResponseAction;
   protected T data;
 }

--- a/src/main/java/org/example/services/GameOverService.java
+++ b/src/main/java/org/example/services/GameOverService.java
@@ -11,7 +11,7 @@ import org.example.entities.game.GameDbService;
 import org.example.entities.player.Player;
 import org.example.entities.stats.Stats;
 import org.example.entities.stats.StatsDbService;
-import org.example.enums.Action;
+import org.example.enums.WebsocketResponseAction;
 import org.example.enums.GameMode;
 import org.example.enums.GameStatus;
 import org.example.enums.ResultReason;
@@ -131,7 +131,7 @@ public class GameOverService {
   private void emitOutcome() throws InternalServerError {
     String messageJson =
         new SocketResponseBody<>(
-                Action.GAME_OVER,
+                WebsocketResponseAction.GAME_OVER,
                 new GameOverMessageData(resultReason, winningPlayerUsername, losingPlayerUsername))
             .toJSON();
     socketMessenger.sendMessages(losingPlayerId, winningPlayerId, messageJson);

--- a/src/main/java/org/example/services/GameOverService.java
+++ b/src/main/java/org/example/services/GameOverService.java
@@ -129,12 +129,15 @@ public class GameOverService {
   }
 
   private void emitOutcome() throws InternalServerError {
+    String connId = this.game.getPlayers().get(0).getConnectionId();
+    String connId2 = this.game.getPlayers().get(1).getConnectionId();
+
     String messageJson =
         new SocketResponseBody<>(
                 WebsocketResponseAction.GAME_OVER,
                 new GameOverMessageData(resultReason, winningPlayerUsername, losingPlayerUsername))
             .toJSON();
-    socketMessenger.sendMessages(losingPlayerId, winningPlayerId, messageJson);
+    socketMessenger.sendMessages(connId, connId2, messageJson);
   }
 
   public void archiveGame() {

--- a/src/test/java/org/example/handlers/makeMove/MakeMoveHandlerTest.java
+++ b/src/test/java/org/example/handlers/makeMove/MakeMoveHandlerTest.java
@@ -17,7 +17,7 @@ import org.example.entities.move.Move;
 import org.example.entities.player.Player;
 import org.example.entities.stats.Stats;
 import org.example.entities.user.User;
-import org.example.enums.Action;
+import org.example.enums.WebsocketResponseAction;
 import org.example.enums.TimeControl;
 import org.example.exceptions.NotFound;
 import org.example.handlers.websocket.JoinGameHandler;
@@ -278,7 +278,7 @@ public class MakeMoveHandlerTest {
             299,
             300);
     SocketResponseBody<MakeMoveMessageData> expectedResponse =
-        new SocketResponseBody<>(Action.MOVE_MADE, data);
+        new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
     assertEquals(expectedResponse.toJSON(), response.getBody());
   }
 
@@ -367,7 +367,7 @@ public class MakeMoveHandlerTest {
             299,
             299);
     SocketResponseBody<MakeMoveMessageData> expectedResponse =
-        new SocketResponseBody<>(Action.MOVE_MADE, data);
+        new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
     assertEquals(expectedResponse.toJSON(), response.getBody());
   }
 
@@ -409,7 +409,7 @@ public class MakeMoveHandlerTest {
             299);
 
     SocketResponseBody<MakeMoveMessageData> expectedResponse =
-        new SocketResponseBody<>(Action.MOVE_MADE, data);
+        new SocketResponseBody<>(WebsocketResponseAction.MOVE_MADE, data);
     assertEquals(expectedResponse.toJSON(), response.getBody());
   }
 }

--- a/src/test/java/org/example/handlers/offerDraw/OfferDrawHandlerTest.java
+++ b/src/test/java/org/example/handlers/offerDraw/OfferDrawHandlerTest.java
@@ -16,6 +16,7 @@ import org.example.entities.game.GameDbService;
 import org.example.entities.stats.StatsDbService;
 import org.example.entities.user.User;
 import org.example.entities.user.UserDbService;
+import org.example.enums.OfferDrawAction;
 import org.example.enums.ResultReason;
 import org.example.enums.TimeControl;
 import org.example.exceptions.NotFound;
@@ -67,7 +68,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "cancel"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.CANCEL);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -98,7 +99,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "deny"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.DENY);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -129,7 +130,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "accept"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.ACCEPT);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -160,7 +161,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "offer"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.OFFER);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -192,7 +193,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "offer"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.OFFER);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -224,7 +225,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "cancel"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.CANCEL);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -259,7 +260,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "offer"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.OFFER);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -291,7 +292,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "accept"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.ACCEPT);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -330,7 +331,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "deny"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.DENY);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -369,7 +370,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "offer"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.OFFER);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -401,7 +402,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest(game.getId(), "accept"); // TODO: change action to something else
+        new OfferDrawRequest(game.getId(), OfferDrawAction.ACCEPT);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =
@@ -453,7 +454,7 @@ public class OfferDrawHandlerTest {
 
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     OfferDrawRequest request =
-        new OfferDrawRequest("nonexistinggame", "offer"); // TODO: change action to something else
+        new OfferDrawRequest("nonexistinggame", OfferDrawAction.OFFER);
     event.setBody(new Gson().toJson(request));
 
     APIGatewayV2WebSocketEvent.RequestContext requestContext =


### PR DESCRIPTION
### Summary

Refactors OfferDraw websocket endpoint to accept control draw actions using enum instead of string. Also moves more logic out of handler and into service.

Includes small bug fixes and other refactoring:
- GameOverService::emitOutcome() was using playerIds instead of connectionIds to emit a message to players
- Actions enum renamed to WebsocketResponseActions

### Checklist

- [x] Wrote any required new unit and integration tests
- [x] Passed all unit and integration tests :feelsgood:
- [x] Run Google formatter within IDE
- [x] PR title and commit messages are easy for others to follow :doughnut:
