### PR TITLE
feat: create Timeout websocket endpoint with test coverage

### DIFF
--- a/src/main/java/org/example/entities/player/PlayerDbService.java
+++ b/src/main/java/org/example/entities/player/PlayerDbService.java
@@ -1,7 +1,6 @@
 package org.example.entities.player;
 
 import org.example.entities.user.User;
-import org.example.utils.MongoDBUtility;
 
 public class PlayerDbService {
 

--- a/src/main/java/org/example/entities/player/PlayerDbService.java
+++ b/src/main/java/org/example/entities/player/PlayerDbService.java
@@ -1,6 +1,7 @@
 package org.example.entities.player;
 
 import org.example.entities.user.User;
+import org.example.utils.MongoDBUtility;
 
 public class PlayerDbService {
 

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
@@ -1,5 +1,7 @@
 package org.example.handlers.websocket.timeout;
 
+import static org.example.utils.APIGatewayResponseBuilder.makeWebsocketResponse;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketEvent;
@@ -7,53 +9,47 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketRespons
 import com.google.gson.Gson;
 import org.example.constants.StatusCodes;
 import org.example.exceptions.StatusCodeException;
-import org.example.handlers.websocket.resign.ResignGameService;
-import org.example.models.requests.ResignRequest;
 import org.example.models.requests.TimeoutRequest;
 import org.example.utils.ValidateObject;
 import org.example.utils.socketMessenger.SocketEmitter;
 import org.example.utils.socketMessenger.SocketMessenger;
 
-import static org.example.utils.APIGatewayResponseBuilder.makeWebsocketResponse;
-
-
 public class TimeoutHandler
-        implements RequestHandler<APIGatewayV2WebSocketEvent, APIGatewayV2WebSocketResponse> {
+    implements RequestHandler<APIGatewayV2WebSocketEvent, APIGatewayV2WebSocketResponse> {
 
-    private final TimeoutService timeoutService;
-    private final SocketMessenger messenger;
+  private final TimeoutService timeoutService;
+  private final SocketMessenger messenger;
 
-    public TimeoutHandler() {
-        timeoutService = new TimeoutService();
-        messenger = new SocketEmitter();
+  public TimeoutHandler() {
+    timeoutService = new TimeoutService();
+    messenger = new SocketEmitter();
+  }
+
+  public TimeoutHandler(TimeoutService timeoutService, SocketMessenger messenger) {
+    this.timeoutService = timeoutService;
+    this.messenger = messenger;
+  }
+
+  @Override
+  public APIGatewayV2WebSocketResponse handleRequest(
+      APIGatewayV2WebSocketEvent event, Context context) {
+
+    String connectionId = event.getRequestContext().getConnectionId();
+
+    TimeoutRequest request = (new Gson()).fromJson(event.getBody(), TimeoutRequest.class);
+    try {
+      ValidateObject.requireNonNull(request);
+    } catch (NullPointerException e) {
+      return makeWebsocketResponse(StatusCodes.BAD_REQUEST, "Missing argument(s)");
     }
 
-    public TimeoutHandler(TimeoutService timeoutService, SocketMessenger messenger) {
-        this.timeoutService = timeoutService;
-        this.messenger = messenger;
+    try {
+      timeoutService.processTimeout(request.gameId(), connectionId, messenger);
+    } catch (StatusCodeException e) {
+      System.out.println(e.getMessage());
+      return e.makeWebsocketResponse();
     }
 
-    @Override
-    public APIGatewayV2WebSocketResponse handleRequest(
-            APIGatewayV2WebSocketEvent event, Context context) {
-
-        String connectionId = event.getRequestContext().getConnectionId();
-
-        TimeoutRequest request = (new Gson()).fromJson(event.getBody(), TimeoutRequest.class);
-        try {
-            ValidateObject.requireNonNull(request);
-        } catch (NullPointerException e) {
-            return makeWebsocketResponse(StatusCodes.BAD_REQUEST, "Missing argument(s)");
-        }
-
-        try {
-           timeoutService.processTimeout(request.gameId(), connectionId, messenger);
-        } catch (StatusCodeException e) {
-            System.out.println(e.getMessage());
-            return e.makeWebsocketResponse();
-        }
-
-        return makeWebsocketResponse(StatusCodes.OK, "Successfully Registered Timeout!");
-    }
+    return makeWebsocketResponse(StatusCodes.OK, "Successfully Registered Timeout!");
+  }
 }
-

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
@@ -1,0 +1,58 @@
+package org.example.handlers.websocket.timeout;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketResponse;
+import com.google.gson.Gson;
+import org.example.constants.StatusCodes;
+import org.example.exceptions.StatusCodeException;
+import org.example.handlers.websocket.resign.ResignGameService;
+import org.example.models.requests.ResignRequest;
+import org.example.models.requests.TimeoutRequest;
+import org.example.utils.ValidateObject;
+import org.example.utils.socketMessenger.SocketEmitter;
+import org.example.utils.socketMessenger.SocketMessenger;
+
+import static org.example.utils.APIGatewayResponseBuilder.makeWebsocketResponse;
+
+
+public class TimeoutHandler
+        implements RequestHandler<APIGatewayV2WebSocketEvent, APIGatewayV2WebSocketResponse> {
+
+    private final TimeoutService timeoutService;
+    private final SocketMessenger messenger;
+
+    public TimeoutHandler() {
+        timeoutService = new TimeoutService();
+        messenger = new SocketEmitter();
+    }
+
+    public TimeoutHandler(TimeoutService timeoutService, SocketMessenger messenger) {
+        this.timeoutService = timeoutService;
+        this.messenger = messenger;
+    }
+
+    @Override
+    public APIGatewayV2WebSocketResponse handleRequest(
+            APIGatewayV2WebSocketEvent event, Context context) {
+
+        String connectionId = event.getRequestContext().getConnectionId();
+
+        TimeoutRequest request = (new Gson()).fromJson(event.getBody(), TimeoutRequest.class);
+        try {
+            ValidateObject.requireNonNull(request);
+        } catch (NullPointerException e) {
+            return makeWebsocketResponse(StatusCodes.BAD_REQUEST, "Missing argument(s)");
+        }
+
+        try {
+           timeoutService.processTimeout(request.gameId(), connectionId, messenger);
+        } catch (StatusCodeException e) {
+            return e.makeWebsocketResponse();
+        }
+
+        return makeWebsocketResponse(StatusCodes.OK, "Successfully Registered Timeout!");
+    }
+}
+

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
@@ -49,6 +49,7 @@ public class TimeoutHandler
         try {
            timeoutService.processTimeout(request.gameId(), connectionId, messenger);
         } catch (StatusCodeException e) {
+            System.out.println(e.getMessage());
             return e.makeWebsocketResponse();
         }
 

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutHandler.java
@@ -46,7 +46,6 @@ public class TimeoutHandler
     try {
       timeoutService.processTimeout(request.gameId(), connectionId, messenger);
     } catch (StatusCodeException e) {
-      System.out.println(e.getMessage());
       return e.makeWebsocketResponse();
     }
 

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
@@ -1,0 +1,65 @@
+package org.example.handlers.websocket.timeout;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.example.entities.game.Game;
+import org.example.entities.game.GameDbService;
+import org.example.entities.player.Player;
+import org.example.enums.ResultReason;
+import org.example.exceptions.BadRequest;
+import org.example.exceptions.InternalServerError;
+import org.example.exceptions.NotFound;
+import org.example.exceptions.Unauthorized;
+import org.example.handlers.websocket.gameOver.GameOverService;
+import org.example.utils.socketMessenger.SocketMessenger;
+
+import java.util.List;
+
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeoutService {
+    @Builder.Default private final GameDbService gameDbService = new GameDbService();
+
+    public void processTimeout(String gameId, String connectionId, SocketMessenger messenger)
+            throws NotFound, InternalServerError, Unauthorized {
+        Game game;
+        try {
+            game = gameDbService.get(gameId);
+        } catch (NotFound e) {
+            throw new NotFound("No Game found with id " + gameId);
+        }
+
+        List<Player> players = game.getPlayers();
+        Player timedOutPlayer;
+        if(players.getFirst().getRemainingTime() < 1){
+            timedOutPlayer = players.getFirst();
+        }
+        else if(players.getLast().getRemainingTime() < 1){
+            timedOutPlayer = players.getLast();
+        }
+        else {
+            throw new NotFound("Not a valid timeout");
+        }
+
+        if((players.getFirst().getRemainingTime() < 1) && (players.getLast().getRemainingTime() < 1)){
+            throw new InternalServerError("both players have no remaining time...");
+            //maybe make this a draw? It should never happen.
+        }
+
+        Player reportingPlayer =
+                game.getPlayers().stream()
+                        .filter(player -> player.getConnectionId().equals(connectionId))
+                        .findFirst()
+                        .orElseThrow(() -> new Unauthorized("Your connection ID is not bound to this game"));
+        // or Forbidden (or something) because if not found among the two players, that should mean they
+        // aren't in the game?
+
+        GameOverService service =
+                new GameOverService(ResultReason.TIMEOUT, game, timedOutPlayer.getPlayerId(), messenger);
+
+        service.endGame();
+    }
+}

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
@@ -41,11 +41,9 @@ public class TimeoutService {
     List<Player> players = game.getPlayers();
 
     Date lastModified = game.getLastModified();
-    System.out.println("last modified time in seconds" + lastModified.getTime() / 1000);
-    System.out.println("date now in seconds" + new Date().getTime() / 1000);
+
     long t =
         ((new Date().getTime() - lastModified.getTime())) / 1000; // convert to seconds from millis
-    System.out.println("elapsed time in seconds: " + t);
 
     Player activePlayer;
     boolean isWhiteTurn = game.getIsWhitesTurn();
@@ -55,9 +53,8 @@ public class TimeoutService {
     } else {
       activePlayer = players.getLast();
     }
-    System.out.println("active player before adjustment: " + activePlayer);
+
     activePlayer.setRemainingTime((int) (activePlayer.getRemainingTime() - t));
-    System.out.println("active player after adjustment: " + activePlayer);
 
     Player timedOutPlayer;
 

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.example.entities.game.Game;
 import org.example.entities.game.GameDbService;
+import org.example.entities.move.Move;
 import org.example.entities.player.Player;
 import org.example.enums.ResultReason;
 import org.example.exceptions.BadRequest;
@@ -14,6 +15,7 @@ import org.example.exceptions.Unauthorized;
 import org.example.handlers.websocket.gameOver.GameOverService;
 import org.example.utils.socketMessenger.SocketMessenger;
 
+import java.util.Date;
 import java.util.List;
 
 
@@ -43,6 +45,22 @@ public class TimeoutService {
 
 
         List<Player> players = game.getPlayers();
+
+        Date lastModified = game.getLastModified();
+
+        long t = ((new Date().getTime() - lastModified.getTime())) / 1000; // convert to seconds from millis
+
+
+        Player activePlayer;
+        boolean isWhiteTurn = game.getIsWhitesTurn();
+        if ((players.getFirst().getIsWhite() && isWhiteTurn)
+                || (!players.getFirst().getIsWhite() && !isWhiteTurn)) {
+            activePlayer = players.getFirst();
+        } else {
+            activePlayer = players.getLast();
+        }
+        activePlayer.setRemainingTime((int) (activePlayer.getRemainingTime() - t));
+
         Player timedOutPlayer;
 
         if(players.getFirst().getRemainingTime() < 1){

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
@@ -32,8 +32,19 @@ public class TimeoutService {
             throw new NotFound("No Game found with id " + gameId);
         }
 
+
+        Player reportingPlayer =
+                game.getPlayers().stream()
+                        .filter(player -> player.getConnectionId().equals(connectionId))
+                        .findFirst()
+                        .orElseThrow(() -> new Unauthorized("Your connection ID is not bound to this game"));
+        // or Forbidden (or something) because if not found among the two players, that should mean they
+        // aren't in the game?
+
+
         List<Player> players = game.getPlayers();
         Player timedOutPlayer;
+
         if(players.getFirst().getRemainingTime() < 1){
             timedOutPlayer = players.getFirst();
         }
@@ -48,14 +59,6 @@ public class TimeoutService {
             throw new InternalServerError("both players have no remaining time...");
             //maybe make this a draw? It should never happen.
         }
-
-        Player reportingPlayer =
-                game.getPlayers().stream()
-                        .filter(player -> player.getConnectionId().equals(connectionId))
-                        .findFirst()
-                        .orElseThrow(() -> new Unauthorized("Your connection ID is not bound to this game"));
-        // or Forbidden (or something) because if not found among the two players, that should mean they
-        // aren't in the game?
 
         GameOverService service =
                 new GameOverService(ResultReason.TIMEOUT, game, timedOutPlayer.getPlayerId(), messenger);

--- a/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
+++ b/src/main/java/org/example/handlers/websocket/timeout/TimeoutService.java
@@ -1,86 +1,82 @@
 package org.example.handlers.websocket.timeout;
 
+import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.example.entities.game.Game;
 import org.example.entities.game.GameDbService;
-import org.example.entities.move.Move;
 import org.example.entities.player.Player;
 import org.example.enums.ResultReason;
-import org.example.exceptions.BadRequest;
 import org.example.exceptions.InternalServerError;
 import org.example.exceptions.NotFound;
 import org.example.exceptions.Unauthorized;
 import org.example.handlers.websocket.gameOver.GameOverService;
 import org.example.utils.socketMessenger.SocketMessenger;
 
-import java.util.Date;
-import java.util.List;
-
-
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class TimeoutService {
-    @Builder.Default private final GameDbService gameDbService = new GameDbService();
+  @Builder.Default private final GameDbService gameDbService = new GameDbService();
 
-    public void processTimeout(String gameId, String connectionId, SocketMessenger messenger)
-            throws NotFound, InternalServerError, Unauthorized {
-        Game game;
-        try {
-            game = gameDbService.get(gameId);
-        } catch (NotFound e) {
-            throw new NotFound("No Game found with id " + gameId);
-        }
-
-
-        Player reportingPlayer =
-                game.getPlayers().stream()
-                        .filter(player -> player.getConnectionId().equals(connectionId))
-                        .findFirst()
-                        .orElseThrow(() -> new Unauthorized("Your connection ID is not bound to this game"));
-        // or Forbidden (or something) because if not found among the two players, that should mean they
-        // aren't in the game?
-
-
-        List<Player> players = game.getPlayers();
-
-        Date lastModified = game.getLastModified();
-
-        long t = ((new Date().getTime() - lastModified.getTime())) / 1000; // convert to seconds from millis
-
-
-        Player activePlayer;
-        boolean isWhiteTurn = game.getIsWhitesTurn();
-        if ((players.getFirst().getIsWhite() && isWhiteTurn)
-                || (!players.getFirst().getIsWhite() && !isWhiteTurn)) {
-            activePlayer = players.getFirst();
-        } else {
-            activePlayer = players.getLast();
-        }
-        activePlayer.setRemainingTime((int) (activePlayer.getRemainingTime() - t));
-
-        Player timedOutPlayer;
-
-        if(players.getFirst().getRemainingTime() < 1){
-            timedOutPlayer = players.getFirst();
-        }
-        else if(players.getLast().getRemainingTime() < 1){
-            timedOutPlayer = players.getLast();
-        }
-        else {
-            throw new NotFound("Not a valid timeout");
-        }
-
-        if((players.getFirst().getRemainingTime() < 1) && (players.getLast().getRemainingTime() < 1)){
-            throw new InternalServerError("both players have no remaining time...");
-            //maybe make this a draw? It should never happen.
-        }
-
-        GameOverService service =
-                new GameOverService(ResultReason.TIMEOUT, game, timedOutPlayer.getPlayerId(), messenger);
-
-        service.endGame();
+  public void processTimeout(String gameId, String connectionId, SocketMessenger messenger)
+      throws NotFound, InternalServerError, Unauthorized {
+    Game game;
+    try {
+      game = gameDbService.get(gameId);
+    } catch (NotFound e) {
+      throw new NotFound("No Game found with id " + gameId);
     }
+
+    Player reportingPlayer =
+        game.getPlayers().stream()
+            .filter(player -> player.getConnectionId().equals(connectionId))
+            .findFirst()
+            .orElseThrow(() -> new Unauthorized("Your connection ID is not bound to this game"));
+    // or Forbidden (or something) because if not found among the two players, that should mean they
+    // aren't in the game?
+
+    List<Player> players = game.getPlayers();
+
+    Date lastModified = game.getLastModified();
+    System.out.println("last modified time in seconds" + lastModified.getTime() / 1000);
+    System.out.println("date now in seconds" + new Date().getTime() / 1000);
+    long t =
+        ((new Date().getTime() - lastModified.getTime())) / 1000; // convert to seconds from millis
+    System.out.println("elapsed time in seconds: " + t);
+
+    Player activePlayer;
+    boolean isWhiteTurn = game.getIsWhitesTurn();
+    if ((players.getFirst().getIsWhite() && isWhiteTurn)
+        || (!players.getFirst().getIsWhite() && !isWhiteTurn)) {
+      activePlayer = players.getFirst();
+    } else {
+      activePlayer = players.getLast();
+    }
+    System.out.println("active player before adjustment: " + activePlayer);
+    activePlayer.setRemainingTime((int) (activePlayer.getRemainingTime() - t));
+    System.out.println("active player after adjustment: " + activePlayer);
+
+    Player timedOutPlayer;
+
+    if (players.getFirst().getRemainingTime() < 1) {
+      timedOutPlayer = players.getFirst();
+    } else if (players.getLast().getRemainingTime() < 1) {
+      timedOutPlayer = players.getLast();
+    } else {
+      throw new NotFound("Not a valid timeout");
+    }
+
+    if ((players.getFirst().getRemainingTime() < 1) && (players.getLast().getRemainingTime() < 1)) {
+      throw new InternalServerError("both players have no remaining time...");
+      // maybe make this a draw? It should never happen.
+    }
+
+    GameOverService service =
+        new GameOverService(ResultReason.TIMEOUT, game, timedOutPlayer.getPlayerId(), messenger);
+
+    service.endGame();
+  }
 }

--- a/src/main/java/org/example/models/requests/TimeoutRequest.java
+++ b/src/main/java/org/example/models/requests/TimeoutRequest.java
@@ -1,0 +1,3 @@
+package org.example.models.requests;
+
+public record TimeoutRequest(String gameId) {}

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -53,7 +53,8 @@ variable "websocket_lambdas" {
     joinGame   = "org.example.handlers.websocket.joinGame.JoinGameHandler::handleRequest",
     makeMove   = "org.example.handlers.websocket.makeMove.MakeMoveHandler::handleRequest",
     resign     = "org.example.handlers.websocket.resign.ResignGameHandler::handleRequest",
-    offerDraw  = "org.example.handlers.websocket.offerDraw.OfferDrawHandler::handleRequest"
+    offerDraw  = "org.example.handlers.websocket.offerDraw.OfferDrawHandler::handleRequest",
+    timeout    = "org.example.handlers.websocket.timeout.TimeoutHandler::handleRequest"
   }
 }
 

--- a/src/terraform/websocket-api.tf
+++ b/src/terraform/websocket-api.tf
@@ -15,7 +15,8 @@ locals {
     joinGame   = "joinGame",
     makeMove   = "makeMove",
     resign     = "resign",
-    offerDraw  = "offerDraw"
+    offerDraw  = "offerDraw",
+    timeout    = "timeout"
   }
 }
 ################################################################################

--- a/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
+++ b/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
@@ -1,0 +1,176 @@
+package org.example.handlers.timeout;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketResponse;
+import com.google.gson.Gson;
+import org.example.constants.StatusCodes;
+import org.example.entities.game.ArchivedGame;
+import org.example.entities.game.ArchivedGameDbService;
+import org.example.entities.game.Game;
+import org.example.entities.game.GameDbService;
+import org.example.entities.player.ArchivedPlayer;
+import org.example.entities.player.Player;
+import org.example.entities.player.PlayerDbService;
+import org.example.entities.stats.StatsDbService;
+import org.example.entities.user.User;
+import org.example.entities.user.UserDbService;
+import org.example.enums.GameStatus;
+import org.example.enums.ResultReason;
+import org.example.enums.TimeControl;
+import org.example.exceptions.NotFound;
+import org.example.handlers.websocket.resign.ResignGameHandler;
+import org.example.handlers.websocket.resign.ResignGameService;
+import org.example.handlers.websocket.timeout.TimeoutHandler;
+import org.example.handlers.websocket.timeout.TimeoutService;
+import org.example.models.requests.ResignRequest;
+import org.example.models.requests.TimeoutRequest;
+import org.example.utils.MockContext;
+import org.example.utils.socketMessenger.SocketSystemLogger;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.example.utils.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TimeoutHandlerTest {
+    private static ArchivedGameDbService archivedGameDbService;
+    private static UserDbService userDbService;
+    private static StatsDbService statsDbService;
+    private static PlayerDbService playerDbService;
+    private static TimeoutHandler handler;
+    private static Game game;
+    private static Player playerOne;
+    private static Player playerTwo;
+    private static User userOne;
+    private static User userTwo;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        handler = new TimeoutHandler(new TimeoutService(), new SocketSystemLogger());
+
+        archivedGameDbService = ArchivedGameDbService.builder().build();
+        GameDbService gameDbService = new GameDbService();
+        userDbService = new UserDbService();
+        playerDbService = new PlayerDbService();
+        statsDbService = new StatsDbService();
+        userOne = validUser();
+        userTwo = validUser();
+        playerOne = playerDbService.toPlayer(userOne, "whatever", true);
+        playerTwo = playerDbService.toPlayer(userTwo, "secondWhatever", false);
+        playerOne.setRemainingTime(-1);
+        playerTwo.setRemainingTime(12);
+
+        game = Game.builder().
+                moveList(new ArrayList<>()).
+                players(List.of(playerOne, playerTwo)).
+                gameStatus(GameStatus.ONGOING).timeControl(TimeControl.BLITZ_5).
+                build();
+        gameDbService.post(game);
+    }
+
+    @Test
+    @Order(1)
+    public void checkNonPlayerUserTriedTimeoutRequest() {
+        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+        event.setBody(new Gson().toJson(Map.of("gameId", game.getId())));
+
+        APIGatewayV2WebSocketEvent.RequestContext requestContext =
+                new APIGatewayV2WebSocketEvent.RequestContext();
+        requestContext.setConnectionId("some-other-guy");
+        requestContext.setRouteKey("timeout");
+        event.setRequestContext(requestContext);
+
+        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+        assertEquals(StatusCodes.UNAUTHORIZED, response.getStatusCode());
+        assertEquals("Your connection ID is not bound to this game", response.getBody());
+    }
+
+    @Test
+    @Order(2)
+    public void canTimeoutGame() {
+        List<Player> players = game.getPlayers();
+
+        String winningPlayerId = players.getLast().getPlayerId();
+
+        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+        TimeoutRequest request = new TimeoutRequest(game.getId());
+        event.setBody(new Gson().toJson(request));
+
+        APIGatewayV2WebSocketEvent.RequestContext requestContext =
+                new APIGatewayV2WebSocketEvent.RequestContext();
+        requestContext.setConnectionId("whatever");
+        requestContext.setRouteKey("timeout");
+        event.setRequestContext(requestContext);
+
+        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+
+        ArchivedGame archivedGame;
+        try {
+            archivedGame = archivedGameDbService.getArchivedGame(game.getId());
+        } catch (NotFound e) {
+            fail("Game was not successfully archived");
+            return;
+        }
+
+        assertEquals(ResultReason.TIMEOUT, archivedGame.getResultReason());
+
+        ArchivedPlayer winningPlayer = archivedGame.getPlayers().getLast();
+        assertEquals(true, winningPlayer.getIsWinner());
+        assertEquals(winningPlayerId, winningPlayer.getPlayerId());
+    }
+
+    @Test
+    public void checksForMissingBody() {
+        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+        event.setBody(new Gson().toJson(Map.of("foo", "fooagain")));
+
+        APIGatewayV2WebSocketEvent.RequestContext requestContext =
+                new APIGatewayV2WebSocketEvent.RequestContext();
+        requestContext.setConnectionId("foo-id");
+        requestContext.setRouteKey("timeout");
+        event.setRequestContext(requestContext);
+
+        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+        assertEquals(StatusCodes.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Missing argument(s)", response.getBody());
+    }
+
+    @Test
+    public void checksThatGameExists() {
+        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+        String fakeID = "fake";
+        event.setBody(new Gson().toJson(Map.of("gameId", fakeID)));
+
+        APIGatewayV2WebSocketEvent.RequestContext requestContext =
+                new APIGatewayV2WebSocketEvent.RequestContext();
+        requestContext.setConnectionId("foo-id");
+        requestContext.setRouteKey("timeout");
+        event.setRequestContext(requestContext);
+
+        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+        assertEquals(StatusCodes.NOT_FOUND, response.getStatusCode());
+        assertEquals("No Game found with id " + fakeID, response.getBody());
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        archivedGameDbService.deleteArchivedGame(game.getId());
+
+        userDbService.deleteUser(userOne.getId());
+        userDbService.deleteUser(userTwo.getId());
+
+        statsDbService.deleteStats(userOne.getId());
+        statsDbService.deleteStats(userTwo.getId());
+    }
+}
+

--- a/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
+++ b/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
@@ -1,8 +1,16 @@
 package org.example.handlers.timeout;
 
+import static org.example.utils.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2WebSocketResponse;
 import com.google.gson.Gson;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.example.constants.StatusCodes;
 import org.example.entities.game.ArchivedGame;
 import org.example.entities.game.ArchivedGameDbService;
@@ -25,229 +33,223 @@ import org.example.utils.MockContext;
 import org.example.utils.socketMessenger.SocketSystemLogger;
 import org.junit.jupiter.api.*;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import static org.example.utils.TestUtils.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TimeoutHandlerTest {
-    private static ArchivedGameDbService archivedGameDbService;
-    private static GameDbService gameDbService;
-    private static UserDbService userDbService;
-    private static StatsDbService statsDbService;
-    private static PlayerDbService playerDbService;
-    private static TimeoutHandler handler;
-    private static Game game;
-    private static Player playerOne;
-    private static Player playerTwo;
-    private static User userOne;
-    private static User userTwo;
-    private static Game game2;
-    @BeforeAll
-    public static void setUp() throws Exception {
-        handler = new TimeoutHandler(new TimeoutService(), new SocketSystemLogger());
+  private static ArchivedGameDbService archivedGameDbService;
+  private static GameDbService gameDbService;
+  private static UserDbService userDbService;
+  private static StatsDbService statsDbService;
+  private static PlayerDbService playerDbService;
+  private static TimeoutHandler handler;
+  private static Game game;
+  private static Player playerOne;
+  private static Player playerTwo;
+  private static User userOne;
+  private static User userTwo;
+  private static Game game2;
 
-        archivedGameDbService = ArchivedGameDbService.builder().build();
-        gameDbService = new GameDbService();
-        userDbService = new UserDbService();
-        playerDbService = new PlayerDbService();
-        statsDbService = new StatsDbService();
-        userOne = validUser();
-        userTwo = validUser();
-        playerOne = playerDbService.toPlayer(userOne, "whatever", true);
-        playerTwo = playerDbService.toPlayer(userTwo, "secondWhatever", false);
-        playerOne.setRemainingTime(100);
-        playerTwo.setRemainingTime(12);
+  @BeforeAll
+  public static void setUp() throws Exception {
+    handler = new TimeoutHandler(new TimeoutService(), new SocketSystemLogger());
 
-        game = Game.builder().
-                moveList(new ArrayList<>()).
-                players(List.of(playerOne, playerTwo)).
-                gameStatus(GameStatus.ONGOING).timeControl(TimeControl.BLITZ_5).
-                lastModified(new Date()).
-                isWhitesTurn(true).
-                build();
-        gameDbService.post(game);
+    archivedGameDbService = ArchivedGameDbService.builder().build();
+    gameDbService = new GameDbService();
+    userDbService = new UserDbService();
+    playerDbService = new PlayerDbService();
+    statsDbService = new StatsDbService();
+    userOne = validUser();
+    userTwo = validUser();
+    playerOne = playerDbService.toPlayer(userOne, "whatever", true);
+    playerTwo = playerDbService.toPlayer(userTwo, "secondWhatever", false);
+    playerOne.setRemainingTime(100);
+    playerTwo.setRemainingTime(12);
 
-        game2 = Game.builder().
-                moveList(new ArrayList<>()).
-                players(List.of(playerOne, playerTwo)).
-                gameStatus(GameStatus.ONGOING).timeControl(TimeControl.BLITZ_10).
-                lastModified(new Date()).
-                isWhitesTurn(true).
-                build();
-        gameDbService.post(game2);
+    game =
+        Game.builder()
+            .moveList(new ArrayList<>())
+            .players(List.of(playerOne, playerTwo))
+            .gameStatus(GameStatus.ONGOING)
+            .timeControl(TimeControl.BLITZ_5)
+            .lastModified(new Date())
+            .isWhitesTurn(true)
+            .build();
+    gameDbService.post(game);
+
+    game2 =
+        Game.builder()
+            .moveList(new ArrayList<>())
+            .players(List.of(playerOne, playerTwo))
+            .gameStatus(GameStatus.ONGOING)
+            .timeControl(TimeControl.BLITZ_10)
+            .lastModified(new Date())
+            .isWhitesTurn(true)
+            .build();
+    gameDbService.post(game2);
+  }
+
+  @Test
+  @Order(1)
+  public void checkNonPlayerUserTriedTimeoutRequest() {
+    APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+    event.setBody(new Gson().toJson(Map.of("gameId", game.getId())));
+
+    APIGatewayV2WebSocketEvent.RequestContext requestContext =
+        new APIGatewayV2WebSocketEvent.RequestContext();
+    requestContext.setConnectionId("some-other-guy");
+    requestContext.setRouteKey("timeout");
+    event.setRequestContext(requestContext);
+
+    APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+    assertEquals(StatusCodes.UNAUTHORIZED, response.getStatusCode());
+    assertEquals("Your connection ID is not bound to this game", response.getBody());
+  }
+
+  @Test
+  @Order(2)
+  public void falseTimeoutReturnsNotFound() {
+
+    APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+    TimeoutRequest request = new TimeoutRequest(game.getId());
+    event.setBody(new Gson().toJson(request));
+
+    APIGatewayV2WebSocketEvent.RequestContext requestContext =
+        new APIGatewayV2WebSocketEvent.RequestContext();
+    requestContext.setConnectionId("whatever");
+    requestContext.setRouteKey("timeout");
+    event.setRequestContext(requestContext);
+
+    APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+    assertEquals(StatusCodes.NOT_FOUND, response.getStatusCode());
+  }
+
+  @Test
+  @Order(3)
+  public void canTimeoutGame() {
+    List<Player> players = game.getPlayers();
+    players.getFirst().setRemainingTime(-1);
+    players.getLast().setRemainingTime(21);
+    gameDbService.put(game.getId(), game);
+
+    String winningPlayerId = players.getLast().getPlayerId();
+
+    APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+    TimeoutRequest request = new TimeoutRequest(game.getId());
+    event.setBody(new Gson().toJson(request));
+
+    APIGatewayV2WebSocketEvent.RequestContext requestContext =
+        new APIGatewayV2WebSocketEvent.RequestContext();
+    requestContext.setConnectionId("whatever");
+    requestContext.setRouteKey("timeout");
+    event.setRequestContext(requestContext);
+
+    APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+    assertEquals(StatusCodes.OK, response.getStatusCode());
+
+    ArchivedGame archivedGame;
+    try {
+      archivedGame = archivedGameDbService.getArchivedGame(game.getId());
+    } catch (NotFound e) {
+      fail("Game was not successfully archived");
+      return;
     }
 
-    @Test
-    @Order(1)
-    public void checkNonPlayerUserTriedTimeoutRequest() {
-        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
-        event.setBody(new Gson().toJson(Map.of("gameId", game.getId())));
+    assertEquals(ResultReason.TIMEOUT, archivedGame.getResultReason());
 
-        APIGatewayV2WebSocketEvent.RequestContext requestContext =
-                new APIGatewayV2WebSocketEvent.RequestContext();
-        requestContext.setConnectionId("some-other-guy");
-        requestContext.setRouteKey("timeout");
-        event.setRequestContext(requestContext);
+    ArchivedPlayer winningPlayer = archivedGame.getPlayers().getLast();
+    assertEquals(true, winningPlayer.getIsWinner());
+    assertEquals(winningPlayerId, winningPlayer.getPlayerId());
+  }
 
-        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+  @Test
+  @Order(4)
+  public void canOtherPlayerTimeoutGame() {
 
-        assertEquals(StatusCodes.UNAUTHORIZED, response.getStatusCode());
-        assertEquals("Your connection ID is not bound to this game", response.getBody());
+    List<Player> players = game2.getPlayers();
+    players.getFirst().setRemainingTime(100); // winning player
+    players.getLast().setRemainingTime(0); // losing player
+
+    gameDbService.put(game2.getId(), game2);
+
+    String winningPlayerId = players.getFirst().getPlayerId();
+
+    APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+    TimeoutRequest request = new TimeoutRequest(game2.getId());
+    event.setBody(new Gson().toJson(request));
+
+    APIGatewayV2WebSocketEvent.RequestContext requestContext =
+        new APIGatewayV2WebSocketEvent.RequestContext();
+    requestContext.setConnectionId("whatever");
+    requestContext.setRouteKey("timeout");
+    event.setRequestContext(requestContext);
+
+    APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+    assertEquals(StatusCodes.OK, response.getStatusCode());
+
+    ArchivedGame archivedGame;
+    try {
+      archivedGame = archivedGameDbService.getArchivedGame(game2.getId());
+    } catch (NotFound e) {
+      fail("Game was not successfully archived");
+      return;
     }
 
-    @Test
-    @Order(2)
-    public void falseTimeoutReturnsNotFound() {
+    assertEquals(ResultReason.TIMEOUT, archivedGame.getResultReason());
 
-        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
-        TimeoutRequest request = new TimeoutRequest(game.getId());
-        event.setBody(new Gson().toJson(request));
+    ArchivedPlayer winningPlayer = archivedGame.getPlayers().getFirst();
+    assertEquals(true, winningPlayer.getIsWinner());
+    assertEquals(winningPlayerId, winningPlayer.getPlayerId());
+  }
 
-        APIGatewayV2WebSocketEvent.RequestContext requestContext =
-                new APIGatewayV2WebSocketEvent.RequestContext();
-        requestContext.setConnectionId("whatever");
-        requestContext.setRouteKey("timeout");
-        event.setRequestContext(requestContext);
+  @Test
+  @Order(5)
+  public void checksForMissingBody() {
+    APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+    event.setBody(new Gson().toJson(Map.of("foo", "fooagain")));
 
-        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+    APIGatewayV2WebSocketEvent.RequestContext requestContext =
+        new APIGatewayV2WebSocketEvent.RequestContext();
+    requestContext.setConnectionId("foo-id");
+    requestContext.setRouteKey("timeout");
+    event.setRequestContext(requestContext);
 
-        assertEquals(StatusCodes.NOT_FOUND, response.getStatusCode());
-    }
+    APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
 
-    @Test
-    @Order(3)
-    public void canTimeoutGame() {
-        List<Player> players = game.getPlayers();
-        players.getFirst().setRemainingTime(-1);
-        players.getLast().setRemainingTime(21);
-        gameDbService.put(game.getId(), game);
+    assertEquals(StatusCodes.BAD_REQUEST, response.getStatusCode());
+    assertEquals("Missing argument(s)", response.getBody());
+  }
 
-        String winningPlayerId = players.getLast().getPlayerId();
+  @Test
+  @Order(6)
+  public void checksThatGameExists() {
+    APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+    String fakeID = "fake";
+    event.setBody(new Gson().toJson(Map.of("gameId", fakeID)));
 
-        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
-        TimeoutRequest request = new TimeoutRequest(game.getId());
-        event.setBody(new Gson().toJson(request));
+    APIGatewayV2WebSocketEvent.RequestContext requestContext =
+        new APIGatewayV2WebSocketEvent.RequestContext();
+    requestContext.setConnectionId("foo-id");
+    requestContext.setRouteKey("timeout");
+    event.setRequestContext(requestContext);
 
-        APIGatewayV2WebSocketEvent.RequestContext requestContext =
-                new APIGatewayV2WebSocketEvent.RequestContext();
-        requestContext.setConnectionId("whatever");
-        requestContext.setRouteKey("timeout");
-        event.setRequestContext(requestContext);
+    APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
 
-        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+    assertEquals(StatusCodes.NOT_FOUND, response.getStatusCode());
+    assertEquals("No Game found with id " + fakeID, response.getBody());
+  }
 
-        assertEquals(StatusCodes.OK, response.getStatusCode());
+  @AfterAll
+  public static void tearDown() {
+    archivedGameDbService.deleteArchivedGame(game.getId());
+    archivedGameDbService.deleteArchivedGame(game2.getId());
 
-        ArchivedGame archivedGame;
-        try {
-            archivedGame = archivedGameDbService.getArchivedGame(game.getId());
-        } catch (NotFound e) {
-            fail("Game was not successfully archived");
-            return;
-        }
+    userDbService.deleteUser(userOne.getId());
+    userDbService.deleteUser(userTwo.getId());
 
-        assertEquals(ResultReason.TIMEOUT, archivedGame.getResultReason());
-
-        ArchivedPlayer winningPlayer = archivedGame.getPlayers().getLast();
-        assertEquals(true, winningPlayer.getIsWinner());
-        assertEquals(winningPlayerId, winningPlayer.getPlayerId());
-    }
-
-    @Test
-    @Order(4)
-    public void canOtherPlayerTimeoutGame() {
-
-        List<Player> players = game2.getPlayers();
-        players.getFirst().setRemainingTime(100); //winning player
-        players.getLast().setRemainingTime(0); //losing player
-
-        gameDbService.put(game2.getId(), game2);
-
-        String winningPlayerId = players.getFirst().getPlayerId();
-
-        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
-        TimeoutRequest request = new TimeoutRequest(game2.getId());
-        event.setBody(new Gson().toJson(request));
-
-        APIGatewayV2WebSocketEvent.RequestContext requestContext =
-                new APIGatewayV2WebSocketEvent.RequestContext();
-        requestContext.setConnectionId("whatever");
-        requestContext.setRouteKey("timeout");
-        event.setRequestContext(requestContext);
-
-        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
-
-        assertEquals(StatusCodes.OK, response.getStatusCode());
-
-        ArchivedGame archivedGame;
-        try {
-            archivedGame = archivedGameDbService.getArchivedGame(game2.getId());
-        } catch (NotFound e) {
-            fail("Game was not successfully archived");
-            return;
-        }
-
-        assertEquals(ResultReason.TIMEOUT, archivedGame.getResultReason());
-
-        ArchivedPlayer winningPlayer = archivedGame.getPlayers().getFirst();
-        assertEquals(true, winningPlayer.getIsWinner());
-        assertEquals(winningPlayerId, winningPlayer.getPlayerId());
-    }
-
-
-    @Test
-    @Order(5)
-    public void checksForMissingBody() {
-        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
-        event.setBody(new Gson().toJson(Map.of("foo", "fooagain")));
-
-        APIGatewayV2WebSocketEvent.RequestContext requestContext =
-                new APIGatewayV2WebSocketEvent.RequestContext();
-        requestContext.setConnectionId("foo-id");
-        requestContext.setRouteKey("timeout");
-        event.setRequestContext(requestContext);
-
-        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
-
-        assertEquals(StatusCodes.BAD_REQUEST, response.getStatusCode());
-        assertEquals("Missing argument(s)", response.getBody());
-    }
-
-    @Test
-    @Order(6)
-    public void checksThatGameExists() {
-        APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
-        String fakeID = "fake";
-        event.setBody(new Gson().toJson(Map.of("gameId", fakeID)));
-
-        APIGatewayV2WebSocketEvent.RequestContext requestContext =
-                new APIGatewayV2WebSocketEvent.RequestContext();
-        requestContext.setConnectionId("foo-id");
-        requestContext.setRouteKey("timeout");
-        event.setRequestContext(requestContext);
-
-        APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
-
-        assertEquals(StatusCodes.NOT_FOUND, response.getStatusCode());
-        assertEquals("No Game found with id " + fakeID, response.getBody());
-    }
-
-    @AfterAll
-    public static void tearDown() {
-        archivedGameDbService.deleteArchivedGame(game.getId());
-        archivedGameDbService.deleteArchivedGame(game2.getId());
-
-        userDbService.deleteUser(userOne.getId());
-        userDbService.deleteUser(userTwo.getId());
-
-        statsDbService.deleteStats(userOne.getId());
-        statsDbService.deleteStats(userTwo.getId());
-    }
+    statsDbService.deleteStats(userOne.getId());
+    statsDbService.deleteStats(userTwo.getId());
+  }
 }
-

--- a/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
+++ b/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
@@ -26,6 +26,7 @@ import org.example.utils.socketMessenger.SocketSystemLogger;
 import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -67,6 +68,8 @@ public class TimeoutHandlerTest {
                 moveList(new ArrayList<>()).
                 players(List.of(playerOne, playerTwo)).
                 gameStatus(GameStatus.ONGOING).timeControl(TimeControl.BLITZ_5).
+                lastModified(new Date()).
+                isWhitesTurn(true).
                 build();
         gameDbService.post(game);
 
@@ -74,6 +77,8 @@ public class TimeoutHandlerTest {
                 moveList(new ArrayList<>()).
                 players(List.of(playerOne, playerTwo)).
                 gameStatus(GameStatus.ONGOING).timeControl(TimeControl.BLITZ_10).
+                lastModified(new Date()).
+                isWhitesTurn(true).
                 build();
         gameDbService.post(game2);
     }

--- a/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
+++ b/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
@@ -125,7 +125,7 @@ public class TimeoutHandlerTest {
   }
 
   @Test
-  @Order(3)
+  @Order(4)
   public void canTimeoutGame() {
     List<Player> players = game.getPlayers();
     players.getFirst().setRemainingTime(-1);
@@ -164,7 +164,30 @@ public class TimeoutHandlerTest {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
+  public void bothPlayersAtZeroReturns500() {
+    List<Player> players = game.getPlayers();
+    players.getFirst().setRemainingTime(-1);
+    players.getLast().setRemainingTime(0);
+    gameDbService.put(game.getId(), game);
+
+    APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
+    TimeoutRequest request = new TimeoutRequest(game.getId());
+    event.setBody(new Gson().toJson(request));
+
+    APIGatewayV2WebSocketEvent.RequestContext requestContext =
+        new APIGatewayV2WebSocketEvent.RequestContext();
+    requestContext.setConnectionId("whatever");
+    requestContext.setRouteKey("timeout");
+    event.setRequestContext(requestContext);
+
+    APIGatewayV2WebSocketResponse response = handler.handleRequest(event, new MockContext());
+
+    assertEquals(StatusCodes.INTERNAL_SERVER_ERROR, response.getStatusCode());
+  }
+
+  @Test
+  @Order(5)
   public void canOtherPlayerTimeoutGame() {
 
     List<Player> players = game2.getPlayers();
@@ -205,7 +228,7 @@ public class TimeoutHandlerTest {
   }
 
   @Test
-  @Order(5)
+  @Order(6)
   public void checksForMissingBody() {
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     event.setBody(new Gson().toJson(Map.of("foo", "fooagain")));
@@ -223,7 +246,7 @@ public class TimeoutHandlerTest {
   }
 
   @Test
-  @Order(6)
+  @Order(7)
   public void checksThatGameExists() {
     APIGatewayV2WebSocketEvent event = new APIGatewayV2WebSocketEvent();
     String fakeID = "fake";


### PR DESCRIPTION
### Summary

creates the timeout websocket route
- takes in a gameId
- authorizes that the request came from a player in the game with id =  gameId via comparing connectionIds 
- validates that one of the players in the game has less than 1 second remaining
- if neither player has actually timed out, throws 404 not found (probably should be bad request though)
- if both players timed out, throws 500 internal server error
- passes control to the GameOverService if one player has in fact timed out

- test coverage 
- [x]  a test to check for internalservererror if both players have less than 1 second remaining

### Checklist

- [x] Wrote any required new unit and integration tests
- [x] Passed all unit and integration tests :feelsgood:
- [x] Run Google formatter within IDE
- [x] PR title and commit messages are easy for others to follow :doughnut:
