### PR TITLE
Fixes ratings not updating

### DIFF
--- a/src/main/java/org/example/entities/player/PlayerDbService.java
+++ b/src/main/java/org/example/entities/player/PlayerDbService.java
@@ -4,11 +4,12 @@ import org.example.entities.user.User;
 
 public class PlayerDbService {
 
-  public Player toPlayer(User user, String connectionId, Boolean isWhite) {
+  public Player toPlayer(User user, int rating, String connectionId, Boolean isWhite) {
     return Player.builder()
         .playerId(user.getId())
         .username(user.getUsername())
         .remainingTime(1)
+        .rating(rating)
         .connectionId(connectionId)
         .isWhite(isWhite)
         .build();

--- a/src/main/java/org/example/entities/stats/GameModeStats.java
+++ b/src/main/java/org/example/entities/stats/GameModeStats.java
@@ -3,10 +3,14 @@ package org.example.entities.stats;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.example.annotations.GsonExcludeField;
 import org.example.constants.ChessConstants;
 
 @Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class GameModeStats {
   private Integer wins;
@@ -16,14 +20,6 @@ public class GameModeStats {
 
   @GsonExcludeField
   private Double RD; // rating deviation used in Glicko rating system (what chess.com uses)
-
-  public GameModeStats() {
-    this(ChessConstants.BASE_RATING, ChessConstants.BASE_RD);
-  }
-
-  public GameModeStats(int rating) {
-    this(rating, ChessConstants.BASE_RD);
-  }
 
   public GameModeStats(int rating, double rd) {
     this.wins = 0;

--- a/src/main/java/org/example/entities/stats/GameModeStats.java
+++ b/src/main/java/org/example/entities/stats/GameModeStats.java
@@ -1,0 +1,130 @@
+package org.example.entities.stats;
+
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.annotations.GsonExcludeField;
+import org.example.constants.ChessConstants;
+
+@Getter
+@AllArgsConstructor
+public class GameModeStats {
+  private Integer wins;
+  private Integer losses;
+  private Integer draws;
+  private Integer rating;
+
+  @GsonExcludeField
+  private Double RD; // rating deviation used in Glicko rating system (what chess.com uses)
+
+  public GameModeStats() {
+    this(ChessConstants.BASE_RATING, ChessConstants.BASE_RD);
+  }
+
+  public GameModeStats(int rating) {
+    this(rating, ChessConstants.BASE_RD);
+  }
+
+  public GameModeStats(int rating, double rd) {
+    this.wins = 0;
+    this.losses = 0;
+    this.draws = 0;
+    this.rating = rating;
+    this.RD = rd;
+    // relatively high uncertainty for new players allows new players to arrive
+    // at their actual rating faster
+  }
+
+  // g is the adjusted impact of the opponent's rating taking into account their RD
+  private double g(double opponentRd) {
+    return 1.0
+        / Math.sqrt(
+            1
+                + 3
+                    * ChessConstants.Q
+                    * ChessConstants.Q
+                    * opponentRd
+                    * opponentRd
+                    / (Math.PI * Math.PI));
+  }
+
+  private double expectedOutcome(double opponentRating, double opponentRd) {
+    double gValue = g(opponentRd);
+    return 1.0
+        / (1.0 + Math.exp(-gValue * (this.rating - opponentRating) / (1.0 / ChessConstants.Q)));
+  }
+
+  public void AddWin(int opponentRating, double opponentRd) {
+    this.wins++;
+    double outcome = 1.0;
+    updateRating(opponentRating, opponentRd, outcome);
+  }
+
+  public void AddLoss(int opponentRating, double opponentRd) {
+    this.losses++;
+    double outcome = 0.0;
+    updateRating(opponentRating, opponentRd, outcome);
+  }
+
+  public void AddDraw(int opponentRating, double opponentRd) {
+    this.draws++;
+    double outcome = 0.5;
+    updateRating(opponentRating, opponentRd, outcome);
+  }
+
+  private void updateRating(int opponentRating, double opponentRd, double outcome) {
+    double gValue = g(opponentRd);
+    double expectedOutcome = expectedOutcome(opponentRating, opponentRd);
+
+    // Simplified Glicko-1 update equation
+    double dSquared =
+        1.0
+            / (ChessConstants.Q
+                * ChessConstants.Q
+                * gValue
+                * gValue
+                * expectedOutcome
+                * (1 - expectedOutcome));
+    double rdNew = 1.0 / Math.sqrt(1.0 / (RD * RD) + 1.0 / dSquared);
+
+    double ratingChange =
+        ChessConstants.Q
+            / ((1.0 / (RD * RD)) + (1.0 / dSquared))
+            * gValue
+            * (outcome - expectedOutcome);
+    this.rating += (int) Math.round(ratingChange);
+    this.RD = rdNew;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+
+    sb.append("GameModeStats{");
+    sb.append("wins=").append(wins);
+    sb.append(", losses=").append(losses);
+    sb.append(", draws=").append(draws);
+    sb.append(", rating=").append(rating);
+    sb.append(", RD=").append(RD);
+    sb.append("}");
+
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GameModeStats gameModeStats = (GameModeStats) o;
+    return Objects.equals(wins, gameModeStats.wins)
+        && Objects.equals(losses, gameModeStats.losses)
+        && Objects.equals(draws, gameModeStats.draws)
+        && Objects.equals(rating, gameModeStats.rating)
+        && Objects.equals(RD, gameModeStats.RD);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(wins, losses, draws, rating, RD);
+  }
+}

--- a/src/main/java/org/example/entities/stats/Stats.java
+++ b/src/main/java/org/example/entities/stats/Stats.java
@@ -9,8 +9,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.example.annotations.CustomExclusionPolicy;
-import org.example.annotations.GsonExcludeField;
-import org.example.constants.ChessConstants;
 import org.example.entities.DataTransferObject;
 import org.example.enums.GameMode;
 
@@ -109,114 +107,5 @@ public class Stats extends DataTransferObject {
   @Override
   public int hashCode() {
     return Objects.hash(id, gameModeStats);
-  }
-
-  @Getter
-  @AllArgsConstructor
-  public static class GameModeStats {
-    // TODO: Move this to its own class?
-    private Integer wins;
-    private Integer losses;
-    private Integer draws;
-    private Integer rating;
-
-    @GsonExcludeField
-    private Double RD; // rating deviation used in Glicko rating system (what chess.com uses)
-
-    public GameModeStats() {
-      this(ChessConstants.BASE_RATING, ChessConstants.BASE_RD);
-    }
-
-    public GameModeStats(int rating) {
-      this(rating, ChessConstants.BASE_RD);
-    }
-
-    public GameModeStats(int rating, double rd) {
-      this.wins = 0;
-      this.losses = 0;
-      this.draws = 0;
-      this.rating = rating;
-      this.RD = rd;
-      // relatively high uncertainty for new players allows new players to arrive
-      // at their actual rating faster
-    }
-
-    // g is the adjusted impact of the opponent's rating taking into account their RD
-    private double g(double opponentRd) {
-      return 1.0
-          / Math.sqrt(
-              1
-                  + 3
-                      * ChessConstants.Q
-                      * ChessConstants.Q
-                      * opponentRd
-                      * opponentRd
-                      / (Math.PI * Math.PI));
-    }
-
-    private double expectedOutcome(double opponentRating, double opponentRd) {
-      double gValue = g(opponentRd);
-      return 1.0
-          / (1.0 + Math.exp(-gValue * (this.rating - opponentRating) / (1.0 / ChessConstants.Q)));
-    }
-
-    public void AddWin(int opponentRating, double opponentRd) {
-      this.wins++;
-      double outcome = 1.0;
-      updateRating(opponentRating, opponentRd, outcome);
-    }
-
-    public void AddLoss(int opponentRating, double opponentRd) {
-      this.losses++;
-      double outcome = 0.0;
-      updateRating(opponentRating, opponentRd, outcome);
-    }
-
-    public void AddDraw(int opponentRating, double opponentRd) {
-      this.draws++;
-      double outcome = 0.5;
-      updateRating(opponentRating, opponentRd, outcome);
-    }
-
-    private void updateRating(int opponentRating, double opponentRd, double outcome) {
-      double gValue = g(opponentRd);
-      double expectedOutcome = expectedOutcome(opponentRating, opponentRd);
-
-      // Simplified Glicko-1 update equation
-      double dSquared =
-          1.0
-              / (ChessConstants.Q
-                  * ChessConstants.Q
-                  * gValue
-                  * gValue
-                  * expectedOutcome
-                  * (1 - expectedOutcome));
-      double rdNew = 1.0 / Math.sqrt(1.0 / (RD * RD) + 1.0 / dSquared);
-
-      double ratingChange =
-          ChessConstants.Q
-              / ((1.0 / (RD * RD)) + (1.0 / dSquared))
-              * gValue
-              * (outcome - expectedOutcome);
-      this.rating += (int) Math.round(ratingChange);
-      this.RD = rdNew;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      GameModeStats gameModeStats = (GameModeStats) o;
-      return Objects.equals(wins, gameModeStats.wins)
-          && Objects.equals(losses, gameModeStats.losses)
-          && Objects.equals(draws, gameModeStats.draws)
-          && Objects.equals(rating, gameModeStats.rating)
-          && Objects.equals(RD, gameModeStats.RD);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(wins, losses, draws, rating, RD);
-    }
   }
 }

--- a/src/main/java/org/example/entities/stats/Stats.java
+++ b/src/main/java/org/example/entities/stats/Stats.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.example.annotations.CustomExclusionPolicy;
+import org.example.constants.ChessConstants;
 import org.example.entities.DataTransferObject;
 import org.example.enums.GameMode;
 
@@ -26,7 +27,7 @@ public class Stats extends DataTransferObject {
     this.gameModeStats = new HashMap<>();
     for (GameMode gameMode : GameMode.values()) {
       // case insensitive
-      gameModeStats.put(gameMode.asKey(), new GameModeStats());
+      gameModeStats.put(gameMode.asKey(), new GameModeStats(ChessConstants.BASE_RATING, ChessConstants.BASE_RD));
     }
   }
 
@@ -106,6 +107,6 @@ public class Stats extends DataTransferObject {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, gameModeStats);
+    return Objects.hash(id, Objects.hash(gameModeStats));
   }
 }

--- a/src/main/java/org/example/entities/stats/StatsDbService.java
+++ b/src/main/java/org/example/entities/stats/StatsDbService.java
@@ -1,6 +1,8 @@
 package org.example.entities.stats;
 
 import java.util.Optional;
+
+import org.bson.conversions.Bson;
 import org.example.entities.user.User;
 import org.example.exceptions.InternalServerError;
 import org.example.utils.MongoDBUtility;
@@ -22,7 +24,7 @@ public class StatsDbService {
   public Stats getStatsByUserID(String userId) throws InternalServerError {
     return statsDBUtility
         .get(userId)
-        .orElseThrow(() -> new InternalServerError("Missing User's Stats"));
+        .orElseThrow(() -> new InternalServerError("Missing User's Stats for userId: " + userId));
   }
 
   public void deleteStats(String id) {
@@ -31,5 +33,13 @@ public class StatsDbService {
 
   public void post(Stats stats) {
     statsDBUtility.post(stats);
+  }
+
+  public void put(String id, Stats stats) {
+    statsDBUtility.put(id, stats);
+  }
+
+  public void patch(String id, Bson filter) {
+    statsDBUtility.patch(id, filter);
   }
 }

--- a/src/main/java/org/example/handlers/websocket/gameOver/GameOverService.java
+++ b/src/main/java/org/example/handlers/websocket/gameOver/GameOverService.java
@@ -178,8 +178,7 @@ public class GameOverService {
       default -> throw new InternalServerError("Unsupported ResultReason: " + resultReason);
     }
 
-    MongoDBUtility<Stats> statsUtility = new MongoDBUtility<>("stats", Stats.class);
-    statsUtility.put(winningPlayerId, winningPlayerStats);
-    statsUtility.put(losingPlayerId, losingPlayerStats);
+    statsDbService.put(winningPlayerId, winningPlayerStats);
+    statsDbService.put(losingPlayerId, losingPlayerStats);
   }
 }

--- a/src/main/java/org/example/handlers/websocket/gameOver/GameOverService.java
+++ b/src/main/java/org/example/handlers/websocket/gameOver/GameOverService.java
@@ -9,6 +9,7 @@ import org.example.entities.game.ArchivedGameDbService;
 import org.example.entities.game.Game;
 import org.example.entities.game.GameDbService;
 import org.example.entities.player.Player;
+import org.example.entities.stats.GameModeStats;
 import org.example.entities.stats.Stats;
 import org.example.entities.stats.StatsDbService;
 import org.example.enums.GameMode;
@@ -155,8 +156,8 @@ public class GameOverService {
   public void updateRatings() throws InternalServerError {
     GameMode gameMode = game.getTimeControl().getGameMode();
 
-    Stats.GameModeStats winningGameModeStats = winningPlayerStats.getGamemodeStats(gameMode);
-    Stats.GameModeStats losingGameModeStats = losingPlayerStats.getGamemodeStats(gameMode);
+    GameModeStats winningGameModeStats = winningPlayerStats.getGamemodeStats(gameMode);
+    GameModeStats losingGameModeStats = losingPlayerStats.getGamemodeStats(gameMode);
 
     switch (resultReason) {
       // Someone abandoned the game: AFK, abandoned / logged out early on
@@ -178,9 +179,7 @@ public class GameOverService {
     }
 
     MongoDBUtility<Stats> statsUtility = new MongoDBUtility<>("stats", Stats.class);
-    statsUtility.patch(
-        winningPlayerId, Updates.set("gameModeStats." + gameMode.asKey(), winningGameModeStats));
-    statsUtility.patch(
-        losingPlayerId, Updates.set("gameModeStats." + gameMode.asKey(), losingGameModeStats));
+    statsUtility.put(winningPlayerId, winningPlayerStats);
+    statsUtility.put(losingPlayerId, losingPlayerStats);
   }
 }

--- a/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveHandler.java
+++ b/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveHandler.java
@@ -131,7 +131,7 @@ public class MakeMoveHandler
       if (service.handleCheckmate(game, socketMessenger))
         return makeWebsocketResponse(StatusCodes.OK, "checkmate");
     } catch (Exception e) {
-      logger.log( "something went wrong when trying to check for checkmate: " + e, LogLevel.ERROR);
+      logger.log("something went wrong when trying to check for checkmate: " + e, LogLevel.ERROR);
     }
 
     try {

--- a/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveHandler.java
+++ b/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveHandler.java
@@ -59,7 +59,7 @@ public class MakeMoveHandler
     String playerId = requestData.getPlayerId();
 
     String gameId = requestData.getGameId();
-    String move = requestData.getMove();
+    String move = requestData.getMove().toLowerCase();
 
     Game game;
     try {

--- a/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveService.java
+++ b/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveService.java
@@ -138,9 +138,11 @@ public class MakeMoveService {
   }
 
   /**
-   * if the game arg is in a state of checkmate, this function will call the GameOverService to handle it
+   * if the game arg is in a state of checkmate, this function will call the GameOverService to
+   * handle it
+   *
    * @return true if it is a checkmate, false otherwise
-   * */
+   */
   public boolean handleCheckmate(Game game, SocketMessenger messenger) throws InternalServerError {
     Board board = Board.fromFEN(game.getGameStateAsFen());
 
@@ -170,8 +172,9 @@ public class MakeMoveService {
 
   /**
    * if the game arg is in a state of draw, this function will call the GameOverService to handle it
+   *
    * @return true if game is drawn, false otherwise
-   * */
+   */
   public boolean handleDraw(Game game, SocketMessenger messenger) throws InternalServerError {
     Board board = Board.fromFEN(game.getGameStateAsFen());
 

--- a/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveService.java
+++ b/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveService.java
@@ -95,7 +95,8 @@ public class MakeMoveService {
 
     // If the piece being moved is a pawn, but promotion not defined
     Board.Piece piece = board.get(moveUCI.substring(0, 2));
-    if (piece.type() == Board.PieceType.PAWN && moveUCI.length() < 5)
+    char toRank = moveUCI.charAt(3);
+    if (piece.type() == Board.PieceType.PAWN && moveUCI.length() < 5 && (toRank == '8' || toRank == '1'))
       moveUCI += 'q'; // promote to queen by default
 
     String san = board.toSAN(moveUCI);

--- a/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveService.java
+++ b/src/main/java/org/example/handlers/websocket/makeMove/MakeMoveService.java
@@ -90,6 +90,7 @@ public class MakeMoveService {
   }
 
   public Game makeMove(String moveUCI, Game game, Date time) throws BadRequest {
+    // Check move is legal
     if (!isMoveLegal(moveUCI))
       throw new BadRequest("Illegal Move: " + moveUCI);
 
@@ -97,8 +98,9 @@ public class MakeMoveService {
     Board.Piece piece = board.get(moveUCI.substring(0, 2));
     char toRank = moveUCI.charAt(3);
     if (piece.type() == Board.PieceType.PAWN && moveUCI.length() < 5 && (toRank == '8' || toRank == '1'))
-      moveUCI += 'q'; // promote to queen by default
+      throw new BadRequest("Pawn being moved can promote, but promotion not defined");
 
+    // Make move
     String san = board.toSAN(moveUCI);
     board = board.play(moveUCI);
 

--- a/src/main/java/org/example/models/responses/rest/ListArchivedGamesResponse.java
+++ b/src/main/java/org/example/models/responses/rest/ListArchivedGamesResponse.java
@@ -16,7 +16,7 @@ public class ListArchivedGamesResponse extends ResponseBody {
 
   @Override
   public String toJSON() {
-    Set<String> fieldsToExclude = Set.of("moveList", "rating");
+    Set<String> fieldsToExclude = Set.of("moveList");
     Gson gsonWithoutMoveList =
         new GsonBuilder()
             .setExclusionStrategies(new FieldExclusionStrategy(fieldsToExclude))

--- a/src/main/java/org/example/utils/MongoDBUtility.java
+++ b/src/main/java/org/example/utils/MongoDBUtility.java
@@ -15,6 +15,8 @@ import com.mongodb.client.model.Indexes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import com.mongodb.client.model.ReplaceOptions;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
@@ -83,6 +85,11 @@ public class MongoDBUtility<T extends DataTransferObject> {
   }
 
   public void put(String id, T object) {
+    ReplaceOptions options = new ReplaceOptions().upsert(true);
+    getCollection().replaceOne(eq("_id", id), object, options);
+  }
+
+  public void replace(String id, T object) {
     getCollection().replaceOne(eq("_id", id), object);
   }
 

--- a/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
+++ b/src/test/java/org/example/handlers/timeout/TimeoutHandlerTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import org.example.constants.ChessConstants;
 import org.example.constants.StatusCodes;
 import org.example.entities.game.ArchivedGame;
 import org.example.entities.game.ArchivedGameDbService;
@@ -59,8 +60,9 @@ public class TimeoutHandlerTest {
     statsDbService = new StatsDbService();
     userOne = validUser();
     userTwo = validUser();
-    playerOne = playerDbService.toPlayer(userOne, "whatever", true);
-    playerTwo = playerDbService.toPlayer(userTwo, "secondWhatever", false);
+    playerOne = playerDbService.toPlayer(userOne, ChessConstants.BASE_RATING, "whatever", true);
+    playerTwo =
+        playerDbService.toPlayer(userTwo, ChessConstants.BASE_RATING, "secondWhatever", false);
     playerOne.setRemainingTime(100);
     playerTwo.setRemainingTime(12);
 

--- a/src/test/java/org/example/utils/TestUtils.java
+++ b/src/test/java/org/example/utils/TestUtils.java
@@ -56,9 +56,13 @@ public class TestUtils {
 
   public static Game validGame(TimeControl timeControl, User playerOne, User playerTwo)
       throws Exception {
-    Game game = new Game(timeControl, playerDbService.toPlayer(playerOne, "foo-id", false));
+    Game game =
+        new Game(
+            timeControl,
+            playerDbService.toPlayer(playerOne, ChessConstants.BASE_RATING, "foo-id", false));
 
-    game.setup(playerDbService.toPlayer(playerTwo, "foo-id-again", false));
+    game.setup(
+        playerDbService.toPlayer(playerTwo, ChessConstants.BASE_RATING, "foo-id-again", false));
 
     return game;
   }


### PR DESCRIPTION
### Summary

Fixes stat rating changes not updating when a game ends.
Extracts `GameModeStats` class into its own file out from `Stats` entity.

Other
- `ListArchivedGamesResponse` no longer excludes rating
- `MongoDBUtility::put` now upserts (posts if nonexistent)
- Adds `MongoDBUtility::replace` to act as `put` without upsert
- Promotion of pawns (to Queen or Knight) allowed in UCI sent in `MakeMove` websocket actions

### Checklist

- [x] Wrote any required new unit and integration tests
- [x] Passed all unit and integration tests :feelsgood:
- [ ] Run Google formatter within IDE
- [x] PR title and commit messages are easy for others to follow :doughnut:
