### PR TITLE
MongoClient now static

### DIFF
--- a/src/main/java/org/example/utils/MongoDBUtility.java
+++ b/src/main/java/org/example/utils/MongoDBUtility.java
@@ -57,7 +57,18 @@ public class MongoDBUtility<T extends DataTransferObject> {
   }
 
   public void createIndex(String field) {
-    getCollection().createIndex(Indexes.ascending(field), new IndexOptions().unique(true));
+    createIndex(field, true);
+  }
+
+  public void createIndex(String field, boolean unique) {
+    getCollection().createIndex(Indexes.ascending(field), new IndexOptions().unique(unique));
+  }
+
+  public void createCompoundIndex(List<String> fields, String indexName, boolean unique) {
+    List<Bson> indexFields = fields.stream().map(Indexes::ascending).toList();
+    Bson compoundIndex = Indexes.compoundIndex(indexFields);
+
+    getCollection().createIndex(compoundIndex, new IndexOptions().name(indexName).unique(unique));
   }
 
   public Optional<T> get(String id) {


### PR DESCRIPTION
### Summary

`MongoClient` usage should be shared for more efficient accessing of documents in collections, instead of instantiating a new object for each collection as this consumes more system resources. This strain is made evident by the roughly 69% reduction of time required to process the entire current unit and integration test suite.

PR also includes functions to define compound indexes in MongoDB.

### Checklist

- [x] Wrote any required new unit and integration tests
- [x] Passed all unit and integration tests :feelsgood:
- [x] Run Google formatter within IDE
- [x] PR title and commit messages are easy for others to follow :doughnut:
