### PR TITLE
Adds support for MongoDB migrations using Liquibase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 src/main/resources/.env
 .env.*
+
+src/main/resources/liquibase.properties

--- a/README.md
+++ b/README.md
@@ -31,15 +31,27 @@ skip tests: ``mvn clean package -DskipTests``
 
 In order for MongoDB to work, you **must** create a `.env` file within `src/main/resources`. It then must include the
 secret
-key, frontend url and connection string.
+key, frontend url and connection string (standard or SRV format allowed).
 
-```text
+```dotenv
 MONGODB_CONNECTION_STRING=fakeconnectionstring
 AWS_REGION=foo-region
 AWS_STAGE=foo-stage
 WEB_SOCKET_BACKEND_ENDPOINT=foowebsocketendpoint
 REST_BACKEND_ENDPOINT=foorestendpoint
 ```
+
+### Database Migrations
+To enable database migrations and be able to apply existing changesets, you **must** create a `liquibase.properties` file within `src/main/resources`.
+It must then include the MongoDB connection string in [**standard format only**](https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format).
+```properties
+url=mongodb://fakeconnectionstring
+```
+You can create a new changeset file from the template using:
+- ``mvn antrun:run@make-changeset``
+- ``mvn antrun:run@make-changeset -DchangesetName=example``
+
+You can apply all existing (and not yet applied) changesets using the command: ``mvn liquibase:update``
 
 ## Testing
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
                 <version>4.28.0</version>
                 <configuration>
                     <propertyFile>src/main/resources/liquibase.properties</propertyFile>
+                    <changeLogFile>src/main/resources/db/changelog/master-changelog.xml</changeLogFile>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.liquibase</groupId>
+                <artifactId>liquibase-maven-plugin</artifactId>
+                <version>4.28.0</version>
+                <configuration>
+                    <propertyFile>src/main/resources/liquibase.properties</propertyFile>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -210,7 +219,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>5.0.0</version>
+            <version>5.2.1</version>
         </dependency>
 
         <!-- dotenv -->
@@ -270,6 +279,17 @@
             <version>0.1.8</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>4.30.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.liquibase.ext</groupId>
+            <artifactId>liquibase-mongodb</artifactId>
+            <version>4.30.0</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,33 @@
                     <propertyFile>src/main/resources/liquibase.properties</propertyFile>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>make-changeset</id>
+                        <configuration>
+                            <target>
+                                <property name="changesetName" value="changeset" />
+                                <tstamp>
+                                    <format property="changesetTimestamp" pattern="yyyyMMddHHmmss" timezone="UTC" />
+                                </tstamp>
+                                <!--suppress UnresolvedMavenProperty -->
+                                <copy file="src/main/resources/db/changelog/changeset.template.xml"
+                                      tofile="src/main/resources/db/changelog/changesets/${changesetTimestamp}_${changesetName}.xml" />
+                                <!--suppress UnresolvedMavenProperty -->
+                                <echo>Created src/main/resources/db/changelog/changesets/${changesetTimestamp}_${changesetName}.xml</echo>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/resources/db/changelog/changeset.template.xml
+++ b/src/main/resources/db/changelog/changeset.template.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mongodb="http://www.liquibase.org/xml/ns/mongodb"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+    http://www.liquibase.org/xml/ns/mongodb
+    http://www.liquibase.org/xml/ns/mongodb/liquibase-mongodb-latest.xsd">
+    
+    <!-- https://contribute.liquibase.com/extensions-integrations/directory/database-tutorials/mongodb/ -->
+    <!-- https://docs.liquibase.com/change-types/mongodb/home.html -->
+
+
+    
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/20241130004935_initial_collections.xml
+++ b/src/main/resources/db/changelog/changesets/20241130004935_initial_collections.xml
@@ -1,0 +1,31 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mongodb="http://www.liquibase.org/xml/ns/mongodb"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+    http://www.liquibase.org/xml/ns/mongodb
+    http://www.liquibase.org/xml/ns/mongodb/liquibase-mongodb-latest.xsd">
+    
+    <!-- https://contribute.liquibase.com/extensions-integrations/directory/database-tutorials/mongodb/ -->
+    <!-- https://docs.liquibase.com/change-types/mongodb/home.html -->
+
+    <changeSet id="1732927811998-1" author="CaiminRO">
+        <mongodb:createCollection collectionName="users" />
+        <mongodb:createCollection collectionName="stats" />
+        <mongodb:createCollection collectionName="sessions" />
+        <mongodb:createCollection collectionName="connections" />
+        <mongodb:createCollection collectionName="games" />
+        <mongodb:createCollection collectionName="archived_games" />
+
+        <rollback>
+            <mongodb:dropCollection collectionName="archived_games" />
+            <mongodb:dropCollection collectionName="games" />
+            <mongodb:dropCollection collectionName="connections" />
+            <mongodb:dropCollection collectionName="sessions" />
+            <mongodb:dropCollection collectionName="stats" />
+            <mongodb:dropCollection collectionName="users" />
+        </rollback>
+    </changeSet>
+    
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/master-changelog.xml
+++ b/src/main/resources/db/changelog/master-changelog.xml
@@ -1,0 +1,9 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <includeAll path="changesets" relativeToChangelogFile="true" />
+
+</databaseChangeLog>


### PR DESCRIPTION
### Summary

Adds Liquibase plugin to enable defining and applying database migrations. Details and requirements defined in new README.
Updates MongoDB dependency `5.0.0` ==> `5.2.1`

### Checklist

- [x] Wrote any required new unit and integration tests
- [x] Passed all unit and integration tests :feelsgood:
- [x] Run Google formatter within IDE
- [x] PR title and commit messages are easy for others to follow :doughnut:
